### PR TITLE
Miscellaneous Refactors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "solidity.packageDefaultDependenciesDirectory": "lib",
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
+  "editor.copyWithSyntaxHighlighting": false,
   "solidity.formatter": "forge",
   "solidity.compileUsingRemoteVersion": "v0.8.17",
   "standard.autoFixOnSave": true,

--- a/client/index.html
+++ b/client/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>veNpm Boost Curve</title>
+  <title>Vote Escrow NPM Boost Curve</title>
   <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
   <script src="../specs/util/calculate-boost.js"></script>
   <style>
@@ -107,7 +107,7 @@
 </head>
 
 <body>
-  <h1>veNpm Boost Curve</h1>
+  <h1>Vote Escrow (veNPM) Boost Curve</h1>
   <div class="container">
     <label>
       <input type="checkbox" id="reverseXAxisCheckbox"> Reverse Lockup Duration

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,4 +1,3 @@
-require('@nomicfoundation/hardhat-foundry')
 require('@openzeppelin/hardhat-upgrades')
 require('hardhat-contract-sizer')
 require('hardhat-gas-reporter')

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "devDependencies": {
     "@neptunemutual/solidoc": "^0.0.2-beta",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
-    "@nomicfoundation/hardhat-foundry": "^1.0.1",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.8",
     "@nomicfoundation/hardhat-verify": "^1.0.0",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
+    "@openzeppelin/contracts-upgradeable": "4.8.3",
     "@openzeppelin/hardhat-upgrades": "^1.24.0",
     "chai": "^4.3.7",
     "dotenv": "10.0.0",

--- a/specs/escrow/ctor.spec.js
+++ b/specs/escrow/ctor.spec.js
@@ -1,0 +1,31 @@
+const factory = require('../util/factory')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: Constructor', () => {
+  let contracts, name, symbol
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.store.address, owner.address, name, symbol)
+
+    contracts.veNpm = veNpm
+  })
+
+  it('must correctly set the state upon construction', async () => {
+    const [owner] = await ethers.getSigners()
+
+    ; (await contracts.veNpm._s()).should.equal(contracts.store.address)
+    ; (await contracts.veNpm.owner()).should.equal(owner.address)
+    ; (await contracts.veNpm._feeTo()).should.equal(owner.address)
+    ; (await contracts.veNpm.name()).should.equal(name)
+    ; (await contracts.veNpm.symbol()).should.equal(symbol)
+    ; (await contracts.veNpm.paused()).should.equal(false)
+  })
+})

--- a/specs/escrow/lock/lock.extension.spec.js
+++ b/specs/escrow/lock/lock.extension.spec.js
@@ -1,0 +1,64 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers')
+const factory = require('../../util/factory')
+const helper = require('../../util/helper')
+const DAYS = 86400
+const WEEKS = 7 * DAYS
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: lock', () => {
+  let contracts, name, symbol
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.store.address, owner.address, name, symbol)
+
+    contracts.veNpm = veNpm
+  })
+
+  it('must correctly extend existing locks', async () => {
+    const [owner, account2] = await ethers.getSigners()
+
+    const amounts = [helper.ether(20_000), helper.ether(50_000)]
+    const durations = [10, 20]
+    const originalLockTimestamps = []
+    const blockSecondsElapsed = [0, 0]
+    const increaseTimeByWeeks = 200
+
+    await contracts.npm.mint(owner.address, amounts[0])
+    await contracts.npm.mint(account2.address, amounts[1])
+
+    await contracts.npm.approve(contracts.veNpm.address, amounts[0])
+    await contracts.npm.connect(account2).approve(contracts.veNpm.address, amounts[1])
+
+    await contracts.veNpm.lock(amounts[0], durations[0]).should.not.be.rejected
+    originalLockTimestamps.push(await time.latest())
+
+    await contracts.veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
+    // first transaction after the previous vote escrow lock
+    // increase the time offset
+    blockSecondsElapsed[0]++
+
+    originalLockTimestamps.push(await time.latest())
+
+    await time.increase(increaseTimeByWeeks * WEEKS)
+
+    await contracts.veNpm.lock(0, durations[0]).should.not.be.rejected
+    blockSecondsElapsed[0]++
+    blockSecondsElapsed[1]++
+
+    ;(await contracts.veNpm._unlockAt(owner.address)).should.equal(originalLockTimestamps[0] + blockSecondsElapsed[0] + ((durations[0] + increaseTimeByWeeks) * WEEKS))
+
+    await contracts.veNpm.connect(account2).lock(0, durations[1]).should.not.be.rejected
+    blockSecondsElapsed[0]++
+    blockSecondsElapsed[1]++
+
+    ;(await contracts.veNpm._unlockAt(account2.address)).should.equal(originalLockTimestamps[1] + blockSecondsElapsed[1] + ((durations[1] + increaseTimeByWeeks) * WEEKS))
+  })
+})

--- a/specs/escrow/lock/lock.spec.js
+++ b/specs/escrow/lock/lock.spec.js
@@ -1,0 +1,58 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers')
+const BigNumber = require('bignumber.js')
+const factory = require('../../util/factory')
+const helper = require('../../util/helper')
+const DAYS = 86400
+const WEEKS = 7 * DAYS
+const MIN_LOCK_HEIGHT = 10
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: lock', () => {
+  let contracts, name, symbol
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.store.address, owner.address, name, symbol)
+
+    contracts.veNpm = veNpm
+  })
+
+  it('must successfully lock NPM tokens', async () => {
+    const [owner, account2] = await ethers.getSigners()
+    const amounts = [helper.ether(20_000), helper.ether(50_000)]
+    const durations = [10, 20]
+    const heights = []
+    const timestamps = []
+
+    await contracts.npm.mint(owner.address, amounts[0])
+    await contracts.npm.mint(account2.address, amounts[1])
+
+    await contracts.npm.approve(contracts.veNpm.address, amounts[0])
+    await contracts.npm.connect(account2).approve(contracts.veNpm.address, amounts[1])
+
+    await contracts.veNpm.lock(amounts[0], durations[0]).should.not.be.rejected
+    heights.push(await ethers.provider.getBlockNumber())
+    timestamps.push(await time.latest())
+
+    await contracts.veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
+    heights.push(await ethers.provider.getBlockNumber())
+    timestamps.push(await time.latest())
+
+    ;(await contracts.veNpm._totalLocked()).should.equal(BigNumber(amounts[0]).plus(amounts[1]))
+
+    ;(await contracts.veNpm._balances(owner.address)).should.equal(amounts[0])
+    ;(await contracts.veNpm._unlockAt(owner.address)).should.equal(timestamps[0] + (durations[0] * WEEKS))
+    ;(await contracts.veNpm._minUnlockHeights(owner.address)).should.equal(heights[0] + MIN_LOCK_HEIGHT)
+
+    ;(await contracts.veNpm._balances(account2.address)).should.equal(amounts[1])
+    ;(await contracts.veNpm._unlockAt(account2.address)).should.equal(timestamps[1] + (durations[1] * WEEKS))
+    ;(await contracts.veNpm._minUnlockHeights(account2.address)).should.equal(heights[1] + MIN_LOCK_HEIGHT)
+  })
+})

--- a/specs/escrow/unlock/unlock-prematurely.spec.js
+++ b/specs/escrow/unlock/unlock-prematurely.spec.js
@@ -1,0 +1,63 @@
+const { mine } = require('@nomicfoundation/hardhat-network-helpers')
+const BigNumber = require('bignumber.js')
+const factory = require('../../util/factory')
+const helper = require('../../util/helper')
+const key = require('../../util/key')
+const MIN_LOCK_HEIGHT = 10
+const PENALTY_RATE = 25
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: unlock', () => {
+  let contracts, name, symbol, durations, amounts
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner, account1, account2] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.store.address, owner.address, name, symbol)
+
+    await contracts.store.setBool(key.qualifyMember(veNpm.address), true)
+
+    amounts = [helper.ether(20_000), helper.ether(50_000)]
+    durations = [10, 20]
+
+    await contracts.npm.mint(account1.address, amounts[0])
+    await contracts.npm.mint(account2.address, amounts[1])
+
+    await contracts.npm.connect(account1).approve(veNpm.address, amounts[0])
+    await contracts.npm.connect(account2).approve(veNpm.address, amounts[1])
+
+    await veNpm.connect(account1).lock(amounts[0], durations[0]).should.not.be.rejected
+    await veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
+
+    contracts.veNpm = veNpm
+    await mine(MIN_LOCK_HEIGHT)
+  })
+
+  it('must correctly perform premature unlocks', async () => {
+    const signers = await ethers.getSigners()
+    let fees = BigNumber(0)
+
+    for (let i = 0; i < 2; i++) {
+      const account = signers[i + 1]
+
+      ;(await contracts.npm.balanceOf(account.address)).should.equal(0)
+      ;(await contracts.veNpm._balances(account.address)).should.equal(amounts[i])
+
+      await contracts.veNpm.approve(contracts.veNpm.address, amounts[i])
+      await contracts.veNpm.connect(account).unlockPrematurely()
+
+      const balance = await contracts.npm.balanceOf(account.address)
+      balance.should.equal(BigNumber(amounts[i]).multipliedBy(100 - PENALTY_RATE).dividedBy(100))
+      fees = fees.plus(BigNumber(amounts[i]).multipliedBy(PENALTY_RATE).dividedBy(100))
+    }
+
+    const [owner] = signers
+    ;(await contracts.npm.balanceOf(owner.address)).should.equal(fees)
+  })
+})

--- a/specs/escrow/unlock/unlock.spec.js
+++ b/specs/escrow/unlock/unlock.spec.js
@@ -1,0 +1,53 @@
+const { time } = require('@nomicfoundation/hardhat-network-helpers')
+const factory = require('../../util/factory')
+const helper = require('../../util/helper')
+const key = require('../../util/key')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: unlock', () => {
+  let contracts, name, symbol, durations, amounts
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner, account2] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.store.address, owner.address, name, symbol)
+
+    await contracts.store.setBool(key.qualifyMember(veNpm.address), true)
+
+    amounts = [helper.ether(20_000), helper.ether(50_000)]
+    durations = [10, 20]
+
+    await contracts.npm.mint(owner.address, amounts[0])
+    await contracts.npm.mint(account2.address, amounts[1])
+
+    await contracts.npm.approve(veNpm.address, amounts[0])
+    await contracts.npm.connect(account2).approve(veNpm.address, amounts[1])
+
+    await veNpm.lock(amounts[0], durations[0]).should.not.be.rejected
+    await veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
+
+    contracts.veNpm = veNpm
+  })
+
+  it('must allow unlocking as soon as the lock period is over', async () => {
+    const signers = await ethers.getSigners()
+
+    for (let i = 0; i < 2; i++) {
+      const account = signers[i]
+      const unlocks = await contracts.veNpm._unlockAt(account.address)
+
+      await time.increaseTo(unlocks)
+
+      ;(await contracts.npm.balanceOf(account.address)).should.equal(0)
+      await contracts.veNpm.approve(contracts.veNpm.address, amounts[i])
+      await contracts.veNpm.connect(account).unlock()
+      ;(await contracts.npm.balanceOf(account.address)).should.equal(amounts[i])
+    }
+  })
+})

--- a/specs/liquidity/pool/ctor.spec.js
+++ b/specs/liquidity/pool/ctor.spec.js
@@ -10,7 +10,8 @@ describe('Liquidity Gauge Pool: Constructor', () => {
   before(async () => {
     const [owner] = await ethers.getSigners()
     contracts = await factory.setGauge(owner)
-    gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, contracts.veNpm.address, contracts.npm.address, contracts.registry.address, contracts.store.address, owner.address)
+
+    gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, contracts.veNpm.address, contracts.registry.address, contracts.store.address, owner.address)
   })
 
   it('must correctly set the state upon construction', async () => {
@@ -18,7 +19,6 @@ describe('Liquidity Gauge Pool: Constructor', () => {
 
     ; (await gaugePool._s()).should.equal(contracts.store.address)
     ; (await gaugePool._veNpm()).should.equal(contracts.veNpm.address)
-    ; (await gaugePool._npm()).should.equal(contracts.npm.address)
     ; (await gaugePool._registry()).should.equal(contracts.registry.address)
     ; (await gaugePool._treasury()).should.equal(owner.address)
   })

--- a/specs/liquidity/registry/add-pool.spec.js
+++ b/specs/liquidity/registry/add-pool.spec.js
@@ -23,8 +23,7 @@ describe('Gauge Controller Registry: Add Pool', () => {
 
     const pool = {
       name: 'Prime dApps',
-      description: 'N/A',
-      data: key.toBytes32(''),
+      info: '',
       platformFee: 1000,
       staking: {
         pod: helper.randomAddress(),
@@ -38,8 +37,7 @@ describe('Gauge Controller Registry: Add Pool', () => {
     const result = await registry.get(k)
 
     result.name.should.equal(pool.name)
-    result.description.should.equal(pool.description)
-    result.data.should.equal(pool.data)
+    result.info.should.equal(pool.info)
     result.platformFee.should.equal(pool.platformFee)
     result.staking.pod.should.equal(pool.staking.pod)
     result.staking.lockupPeriodInBlocks.should.equal(pool.staking.lockupPeriodInBlocks)

--- a/specs/liquidity/registry/set-gauge.spec.js
+++ b/specs/liquidity/registry/set-gauge.spec.js
@@ -11,8 +11,7 @@ const candidates = [{
   key: key.toBytes32('prime'),
   pool: {
     name: 'Prime dApps',
-    description: 'N/A',
-    data: key.toBytes32(''),
+    info: '',
     platformFee: 1000,
     staking: {
       pod: helper.randomAddress(),
@@ -25,8 +24,7 @@ const candidates = [{
   key: key.toBytes32('popular-defi-apps'),
   pool: {
     name: 'Popular DeFi Apps',
-    description: 'N/A',
-    data: key.toBytes32(''),
+    info: '',
     platformFee: 1500,
     staking: {
       pod: helper.randomAddress(),

--- a/specs/util/factory/liquidity-gauge-pool.js
+++ b/specs/util/factory/liquidity-gauge-pool.js
@@ -4,7 +4,7 @@ const { deployUpgradeable } = require('./deployer')
 const deployLiquidityGaugePool = async (signer) => {
   const contracts = await setGauge(signer)
 
-  const gaugePool = await deployUpgradeable('LiquidityGaugePool', signer.address, contracts.veNpm.address, contracts.npm.address, contracts.registry.address, contracts.store.address, signer.address)
+  const gaugePool = await deployUpgradeable('LiquidityGaugePool', signer.address, contracts.veNpm.address, contracts.registry.address, contracts.store.address, signer.address)
 
   contracts.gaugePool = gaugePool
   return contracts

--- a/specs/util/factory/pool.js
+++ b/specs/util/factory/pool.js
@@ -9,14 +9,14 @@ const deployPool = async (signer) => {
   const popularDefiAppsPod = await deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-POP')
 
   const veNpm = await deployUpgradeable('VoteEscrowToken', signer.address, store.address, signer.address, 'Vote Escrow NPM', 'veNPM')
+
   const registry = await deployUpgradeable('GaugeControllerRegistry', signer.address, store.address)
 
   const candidates = [{
     key: key.toBytes32('prime'),
     pool: {
       name: 'Prime dApps',
-      description: 'N/A',
-      data: key.toBytes32(''),
+      info: '',
       platformFee: 1000,
       staking: {
         pod: primeDappsPod.address,
@@ -29,8 +29,7 @@ const deployPool = async (signer) => {
     key: key.toBytes32('popular-defi-apps'),
     pool: {
       name: 'Popular DeFi Apps',
-      description: 'N/A',
-      data: key.toBytes32(''),
+      info: '',
       platformFee: 1500,
       staking: {
         pod: popularDefiAppsPod.address,

--- a/src/escrow/VoteEscrowBooster.sol
+++ b/src/escrow/VoteEscrowBooster.sol
@@ -12,15 +12,15 @@ abstract contract VoteEscrowBooster {
     return 10_000;
   }
 
-  function _calculateBoost(uint256 expiryDuration) internal pure returns (uint256) {
+  function _calculateBoost(uint256 durationInWeeks) internal pure returns (uint256) {
     uint256 _BOOST_FLOOR = 10_000;
     uint256 _BOOST_CEILING = 40_000;
 
-    if (expiryDuration > 1460 days) {
+    if (durationInWeeks > 1460 days) {
       return _BOOST_CEILING;
     }
 
-    uint256 result = expiryDuration.divu(1 days).div(uint256(1460).fromUInt()).mul(_BOOST_CEILING.divu(_denominator()).log_2()).exp_2().mulu(_denominator());
+    uint256 result = durationInWeeks.divu(1 days).div(uint256(1460).fromUInt()).mul(_BOOST_CEILING.divu(_denominator()).log_2()).exp_2().mulu(_denominator());
 
     if (result < _BOOST_FLOOR) {
       return _BOOST_FLOOR;

--- a/src/escrow/VoteEscrowBooster.sol
+++ b/src/escrow/VoteEscrowBooster.sol
@@ -1,5 +1,5 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import "../dependencies/ABDKMath64x64.sol";

--- a/src/escrow/VoteEscrowLocker.sol
+++ b/src/escrow/VoteEscrowLocker.sol
@@ -8,6 +8,11 @@ import "./VoteEscrowTokenState.sol";
 
 abstract contract VoteEscrowLocker is IThrowable, IVoteEscrowLocker, VoteEscrowTokenState {
   function _lock(address account, uint256 amount, uint256 durationInWeeks) internal {
+    if (_balances[account] == 0 && amount == 0) {
+      // You need existing balance before you can extend the vote lock period
+      revert ZeroAmountError("amount");
+    }
+
     uint256 _MIN_LOCK_HEIGHT = 10;
     uint256 newUnlockTimestamp = block.timestamp + (durationInWeeks * 7 days);
 
@@ -32,6 +37,7 @@ abstract contract VoteEscrowLocker is IThrowable, IVoteEscrowLocker, VoteEscrowT
 
   function _unlock(address account, uint256 penalty) internal returns (uint256 amount) {
     amount = _balances[account];
+
     uint256 unlockAt = _unlockAt[account];
 
     if (amount == 0) {

--- a/src/escrow/VoteEscrowLocker.sol
+++ b/src/escrow/VoteEscrowLocker.sol
@@ -1,5 +1,5 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import "./interfaces/IVoteEscrowLocker.sol";

--- a/src/escrow/VoteEscrowToken.sol
+++ b/src/escrow/VoteEscrowToken.sol
@@ -32,7 +32,6 @@ contract VoteEscrowToken is IVoteEscrowToken, ProtocolMembership, WithPausabilit
     super.__ReentrancyGuard_init();
 
     super.transferOwnership(contractOwner);
-    emit VoteEscrowTokenConstructed(address(store), feeToAccount, tokenName, tokenSymbol);
   }
 
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -43,7 +42,7 @@ contract VoteEscrowToken is IVoteEscrowToken, ProtocolMembership, WithPausabilit
 
     // Pull and burn veNpm
     // slither-disable-start arbitrary-send-erc20
-    SafeERC20Upgradeable.safeTransferFrom(this, _msgSender(), address(this), amount);
+    super._transfer(_msgSender(), address(this), amount);
     // slither-disable-end arbitrary-send-erc20
     super._burn(address(this), amount);
 
@@ -51,7 +50,7 @@ contract VoteEscrowToken is IVoteEscrowToken, ProtocolMembership, WithPausabilit
     IERC20Upgradeable(super._getNpm(_s)).safeTransfer(_msgSender(), amount - penalty);
 
     if (penalty > 0) {
-      IERC20Upgradeable(super._getNpm(_s)).safeTransfer(_feeTo, amount - penalty);
+      IERC20Upgradeable(super._getNpm(_s)).safeTransfer(_feeTo, penalty);
     }
   }
 
@@ -135,8 +134,8 @@ contract VoteEscrowToken is IVoteEscrowToken, ProtocolMembership, WithPausabilit
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   //                                             Boost
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-  function calculateBoost(uint256 expiryDuration) external pure override returns (uint256) {
-    return super._calculateBoost(expiryDuration);
+  function calculateBoost(uint256 durationInWeeks) external pure override returns (uint256) {
+    return super._calculateBoost(durationInWeeks);
   }
 
   function getVotingPower(address account) external view override returns (uint256) {

--- a/src/escrow/VoteEscrowToken.sol
+++ b/src/escrow/VoteEscrowToken.sol
@@ -1,5 +1,5 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";

--- a/src/escrow/VoteEscrowTokenState.sol
+++ b/src/escrow/VoteEscrowTokenState.sol
@@ -1,5 +1,5 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import "../dependencies/interfaces/IStore.sol";

--- a/src/escrow/interfaces/IVoteEscrowLocker.sol
+++ b/src/escrow/interfaces/IVoteEscrowLocker.sol
@@ -1,5 +1,5 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 interface IVoteEscrowLocker {

--- a/src/escrow/interfaces/IVoteEscrowToken.sol
+++ b/src/escrow/interfaces/IVoteEscrowToken.sol
@@ -1,5 +1,5 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
@@ -11,10 +11,8 @@ interface IVoteEscrowToken is IThrowable, IERC20Upgradeable, IVoteEscrowLocker {
   function unlock() external;
   function unlockPrematurely() external;
 
-  function calculateBoost(uint256 expiryDuration) external pure returns (uint256);
+  function calculateBoost(uint256 durationInWeeks) external pure returns (uint256);
   function getVotingPower(address account) external view returns (uint256);
-
-  event VoteEscrowTokenConstructed(address store, address feeToAccount, string tokenName, string tokenSymbol);
 
   error VoteEscrowUnlockError(uint256 unlocksAt);
   error VoteEscrowAlreadyUnlockedError();

--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -3,12 +3,11 @@
 pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
-import "../util/ProtocolMembership.sol";
 import "../util/TokenRecovery.sol";
 import "../util/WithPausability.sol";
 import "./LiquidityGaugePoolReward.sol";
 
-contract LiquidityGaugePool is LiquidityGaugePoolReward, ProtocolMembership, WithPausability, TokenRecovery {
+contract LiquidityGaugePool is LiquidityGaugePoolReward, WithPausability, TokenRecovery {
   using SafeERC20Upgradeable for IERC20Upgradeable;
 
   /// @custom:oz-upgrades-unsafe-allow constructor
@@ -16,7 +15,7 @@ contract LiquidityGaugePool is LiquidityGaugePoolReward, ProtocolMembership, Wit
     super._disableInitializers();
   }
 
-  function initialize(address contractOwner, address veNpm, address npm, address registry, IStore protocolStore, address treasury) external initializer {
+  function initialize(address contractOwner, address veNpm, address registry, IStore protocolStore, address treasury) external initializer {
     if (veNpm == address(0)) {
       revert ZeroAddressError("veNPM");
     }
@@ -30,7 +29,7 @@ contract LiquidityGaugePool is LiquidityGaugePoolReward, ProtocolMembership, Wit
     }
 
     _s = protocolStore;
-    _setAddresses(veNpm, npm, registry, treasury);
+    _setAddresses(veNpm, registry, treasury);
 
     super.__Ownable_init();
     super.__Pausable_init();
@@ -39,15 +38,11 @@ contract LiquidityGaugePool is LiquidityGaugePoolReward, ProtocolMembership, Wit
     super.transferOwnership(contractOwner);
   }
 
-  function _setAddresses(address veNpm, address npm, address registry, address treasury) internal {
-    emit LiquidityGaugePoolInitialized(_veNpm, veNpm, _npm, npm, _registry, registry, _treasury, treasury);
+  function _setAddresses(address veNpm, address registry, address treasury) internal {
+    emit LiquidityGaugePoolInitialized(_veNpm, veNpm, _registry, registry, _treasury, treasury);
 
     if (veNpm != address(0)) {
       _veNpm = veNpm;
-    }
-
-    if (npm != address(0)) {
-      _npm = npm;
     }
 
     if (registry != address(0)) {
@@ -59,9 +54,9 @@ contract LiquidityGaugePool is LiquidityGaugePoolReward, ProtocolMembership, Wit
     }
   }
 
-  function setAddresses(address veNpm, address npm, address registry, address treasury) external override onlyOwner {
+  function setAddresses(address veNpm, address registry, address treasury) external override onlyOwner {
     _throwIfProtocolPaused(_s);
-    _setAddresses(veNpm, npm, registry, treasury);
+    _setAddresses(veNpm, registry, treasury);
   }
 
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/gauge-pool/LiquidityGaugePoolReward.sol
+++ b/src/gauge-pool/LiquidityGaugePoolReward.sol
@@ -9,8 +9,9 @@ import "../gauge-registry/GaugeControllerRegistry.sol";
 import "./interfaces/ILiquidityGaugePool.sol";
 import "../escrow/interfaces/IVoteEscrowToken.sol";
 import "./LiquidityGaugePoolState.sol";
+import "../util/ProtocolMembership.sol";
 
-abstract contract LiquidityGaugePoolReward is ILiquidityGaugePool, LiquidityGaugePoolState, ReentrancyGuardUpgradeable, ContextUpgradeable {
+abstract contract LiquidityGaugePoolReward is ILiquidityGaugePool, ProtocolMembership, LiquidityGaugePoolState, ReentrancyGuardUpgradeable, ContextUpgradeable {
   using SafeERC20Upgradeable for IERC20Upgradeable;
 
   function _denominator() private pure returns (uint256) {
@@ -101,11 +102,11 @@ abstract contract LiquidityGaugePoolReward is ILiquidityGaugePool, LiquidityGaug
 
     // Avoid underflow
     if (rewards > platformFee) {
-      IERC20Upgradeable(_npm).safeTransfer(_msgSender(), rewards - platformFee);
+      IERC20Upgradeable(super._getNpm(_s)).safeTransfer(_msgSender(), rewards - platformFee);
     }
 
     if (platformFee > 0) {
-      IERC20Upgradeable(_npm).safeTransfer(_treasury, platformFee);
+      IERC20Upgradeable(super._getNpm(_s)).safeTransfer(_treasury, platformFee);
     }
 
     emit LiquidityGaugeRewardsWithdrawn(key, _msgSender(), _treasury, rewards, platformFee);

--- a/src/gauge-pool/LiquidityGaugePoolState.sol
+++ b/src/gauge-pool/LiquidityGaugePoolState.sol
@@ -12,7 +12,6 @@ abstract contract LiquidityGaugePoolState {
   //                                        Primitive Types
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   address public _veNpm;
-  address public _npm;
   address public _registry;
   address public _treasury;
   address[46] public __address_gap;

--- a/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
+++ b/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
@@ -6,7 +6,7 @@ import "../../gauge-registry/interfaces/IGaugeControllerRegistry.sol";
 import "../../dependencies/interfaces/IMember.sol";
 
 interface ILiquidityGaugePool is IMember {
-  function setAddresses(address veNpm, address npm, address registry, address treasury) external;
+  function setAddresses(address veNpm, address registry, address treasury) external;
   function deposit(bytes32 key, uint256 amount) external;
   function withdraw(bytes32 key, uint256 amount) external;
   function withdrawRewards(bytes32 key) external returns (IGaugeControllerRegistry.PoolSetupArgs memory);
@@ -18,7 +18,7 @@ interface ILiquidityGaugePool is IMember {
   event LiquidityGaugeRewardsWithdrawn(bytes32 indexed key, address indexed account, address treasury, uint256 rewards, uint256 platformFee);
   event LiquidityGaugeDeposited(bytes32 indexed key, address indexed account, address indexed stakingToken, uint256 amount);
   event LiquidityGaugeWithdrawn(bytes32 indexed key, address indexed account, address indexed stakingToken, uint256 amount);
-  event LiquidityGaugePoolInitialized(address previousVeNpm, address veNpm, address previousNpm, address npm, address previousRegistry, address registry, address previousTreasury, address treasury);
+  event LiquidityGaugePoolInitialized(address previousVeNpm, address veNpm, address previousRegistry, address registry, address previousTreasury, address treasury);
 
   error PoolNotFoundError(bytes32 key);
   error PoolNotActiveError(bytes32 key);

--- a/src/gauge-registry/interfaces/IGaugeControllerRegistry.sol
+++ b/src/gauge-registry/interfaces/IGaugeControllerRegistry.sol
@@ -8,13 +8,12 @@ interface IGaugeControllerRegistry {
   struct PodArgs {
     IVault pod;
     uint256 lockupPeriodInBlocks;
-    uint256 ratio; // Approximate ratio (%) of the POD <--> veNpm for boosted emmission
+    uint256 ratio;
   }
 
   struct PoolSetupArgs {
     string name;
-    string description;
-    bytes data;
+    string info;
     uint256 platformFee;
     PodArgs staking;
   }
@@ -24,8 +23,8 @@ interface IGaugeControllerRegistry {
     uint256 emissionPerBlock;
   }
 
-  function setGauge(uint256 epoch, uint256 amountToDeposit, Gauge[] calldata distribution) external;
   function addOrEditPool(bytes32 key, PoolSetupArgs calldata args) external;
+  function setGauge(uint256 epoch, uint256 amountToDeposit, Gauge[] calldata distribution) external;
   function withdrawRewards(bytes32 key, uint256 amount) external;
   function deactivatePool(bytes32 key) external;
   function activatePool(bytes32 key) external;

--- a/src/util/WhitelistedTransfer.sol
+++ b/src/util/WhitelistedTransfer.sol
@@ -34,6 +34,12 @@ abstract contract WhitelistedTransfer is IWhitelistedTransfer, ContextUpgradeabl
       return;
     }
 
+    // Token burns
+    if (to == address(0)) {
+      // aren't restricted either
+      return;
+    }
+
     // Someone not whitelisted
     // ............................ can still transfer to a whitelisted address
     if (_whitelist[from] == false && _whitelist[to] == false) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,13 +977,6 @@
     deep-eql "^4.0.1"
     ordinal "^1.0.3"
 
-"@nomicfoundation/hardhat-foundry@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-foundry/-/hardhat-foundry-1.0.1.tgz#22b11a78a179ec7ed6840ee8c10add888fd23dc8"
-  integrity sha512-sQEaX3rik6Gclmek4MqCyOc9+vOM0ZS40eUARrB6K9t6wthqCwJ29CClfxLdbrjn/3MM5hX8ioD+/9OqdGVxSQ==
-  dependencies:
-    chalk "^2.4.2"
-
 "@nomicfoundation/hardhat-network-helpers@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-1.0.8.tgz#e4fe1be93e8a65508c46d73c41fa26c7e9f84931"
@@ -1076,6 +1069,11 @@
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz#b41053e360c31a32c2640c9a45ee981a7e603fe0"
   integrity sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==
+
+"@openzeppelin/contracts-upgradeable@4.8.3":
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.8.3.tgz#6b076a7b751811b90fe3a172a7faeaa603e13a3f"
+  integrity sha512-SXDRl7HKpl2WDoJpn7CK/M9U4Z8gNXDHHChAKh0Iz+Wew3wu6CmFYBeie3je8V0GSXZAIYYwUktSrnW/kwVPtg==
 
 "@openzeppelin/hardhat-upgrades@^1.24.0":
   version "1.24.0"


### PR DESCRIPTION
## Vote Escrow Token

- The argument `expiryDuration` has been renamed to `durationInWeeks` for both the `_calculateBoost` and `calculateBoost` functions to improve clarity.
- The `_lock` function now throws an error if an account that hasn't previously locked any tokens enters a zero balance. A zero balance can be specified along with `durationInWeeks` after the initial lock to extend an existing lock.
- The internal `transferFrom` function is now used in `_unlockWithPenalty` instead of `SafeERC20Upgradeable.safeTransferFrom`. Additionally, a bug where an incorrect amount was being transferred as a penalty fee has been fixed.
- The obsolete event `VoteEscrowTokenConstructed` has been removed.

## Liquidity Gauge Pools

- The `npm` initializer argument has been removed from the `LiquidityGaugePool` contract since the protocol store instance is already initialized. The protocol store maintains the correct NPM token address.
- The `LiquidityGaugePool` base contract(s) have been updated to retrieve the NPM token instance from the protocol store.

## Gauge Controller Registry

- The variable `description` of `PoolSetupArgs` has been renamed to `info`, which will store the IPFS hash of the gauge pool metadata.
- `_throwIfNonWhitelistedTransfer` function now allows token burning.

## Other Changes

- The dependency `@nomicfoundation/hardhat-foundry` has been removed due to incompatibility with the hardhat solidity-coverage plugin.
- The `@openzeppelin/contracts-upgradeable` dependency has been added.
- A few more unit tests were added.
- Updated the contract `VoteEscrowToken` with the Apache 2 SPDX license identifier.