### PR TITLE
Epoch Block Heights and NFT Bound Token Id

### DIFF
--- a/abis/FakeCxToken.json
+++ b/abis/FakeCxToken.json
@@ -217,7 +217,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "expiresOn",
+        "name": "expiry",
         "type": "uint256"
       }
     ],

--- a/abis/FakeNeptuneLegends.json
+++ b/abis/FakeNeptuneLegends.json
@@ -16,6 +16,27 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "boundTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AlreadyBoundError",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "AlreadyInitializedError",
     "type": "error"
@@ -48,17 +69,6 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "argument",
-        "type": "bytes32"
-      }
-    ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
     "type": "error"
@@ -77,6 +87,17 @@
       }
     ],
     "name": "InvalidAmountError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "argument",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/FakeNeptuneLegendsState.json
+++ b/abis/FakeNeptuneLegendsState.json
@@ -2,6 +2,27 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "boundTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AlreadyBoundError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"

--- a/abis/FakeVoteEscrowLockerV2.json
+++ b/abis/FakeVoteEscrowLockerV2.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/FakeVoteEscrowTokenV2.json
+++ b/abis/FakeVoteEscrowTokenV2.json
@@ -37,6 +37,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -44,12 +49,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/GaugeControllerRegistry.json
+++ b/abis/GaugeControllerRegistry.json
@@ -40,16 +40,38 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "argument",
+        "name": "arg",
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
+    "name": "ConfigurationError",
     "type": "error"
   },
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "endHeight",
+        "type": "uint256"
+      }
+    ],
+    "name": "HeightOverflowError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "argument",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {
@@ -203,7 +225,7 @@
         "type": "uint256"
       }
     ],
-    "name": "ApproximateBlocksPerEpochSet",
+    "name": "BlocksPerEpochSet",
     "type": "event"
   },
   {
@@ -280,6 +302,11 @@
       },
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -596,7 +623,7 @@
   },
   {
     "inputs": [],
-    "name": "_approximateBlocksPerEpoch",
+    "name": "_blocksPerEpoch",
     "outputs": [
       {
         "internalType": "uint256",
@@ -647,6 +674,30 @@
         "type": "uint256"
       }
     ],
+    "name": "_epochs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "startBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "endBlock",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "name": "_gaugeAllocations",
     "outputs": [
       {
@@ -681,6 +732,11 @@
     ],
     "name": "_pools",
     "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
       {
         "internalType": "string",
         "name": "name",
@@ -796,12 +852,12 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      },
-      {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -840,12 +896,12 @@
             "type": "tuple"
           }
         ],
-        "internalType": "struct IGaugeControllerRegistry.PoolSetupArgs",
+        "internalType": "struct IGaugeControllerRegistry.PoolSetupArgs[]",
         "name": "args",
-        "type": "tuple"
+        "type": "tuple[]"
       }
     ],
-    "name": "addOrEditPool",
+    "name": "addOrEditPools",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -888,6 +944,11 @@
     "outputs": [
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -974,6 +1035,62 @@
   },
   {
     "inputs": [],
+    "name": "getEpoch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IGaugeControllerRegistry.Epoch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "getEpoch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IGaugeControllerRegistry.Epoch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getLastEpoch",
     "outputs": [
       {
@@ -1050,7 +1167,7 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "approximateBlocksPerEpoch",
+        "name": "blocksPerEpoch",
         "type": "uint256"
       },
       {
@@ -1208,11 +1325,11 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "approximateBlocksPerEpoch",
+        "name": "blocksPerEpoch",
         "type": "uint256"
       }
     ],
-    "name": "setApproximateBlocksPerEpoch",
+    "name": "setBlocksPerEpoch",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1238,7 +1355,7 @@
           },
           {
             "internalType": "uint256",
-            "name": "emissionPerEpoch",
+            "name": "emission",
             "type": "uint256"
           }
         ],

--- a/abis/GaugeControllerRegistryState.json
+++ b/abis/GaugeControllerRegistryState.json
@@ -1,5 +1,27 @@
 [
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "arg",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ConfigurationError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "endHeight",
+        "type": "uint256"
+      }
+    ],
+    "name": "HeightOverflowError",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "InvalidGaugeEpochError",
     "type": "error"
@@ -113,7 +135,7 @@
         "type": "uint256"
       }
     ],
-    "name": "ApproximateBlocksPerEpochSet",
+    "name": "BlocksPerEpochSet",
     "type": "event"
   },
   {
@@ -190,6 +212,11 @@
       },
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -379,7 +406,7 @@
   },
   {
     "inputs": [],
-    "name": "_approximateBlocksPerEpoch",
+    "name": "_blocksPerEpoch",
     "outputs": [
       {
         "internalType": "uint256",
@@ -430,6 +457,30 @@
         "type": "uint256"
       }
     ],
+    "name": "_epochs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "startBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "endBlock",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "name": "_gaugeAllocations",
     "outputs": [
       {
@@ -464,6 +515,11 @@
     ],
     "name": "_pools",
     "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
       {
         "internalType": "string",
         "name": "name",
@@ -579,12 +635,12 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      },
-      {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -623,12 +679,12 @@
             "type": "tuple"
           }
         ],
-        "internalType": "struct IGaugeControllerRegistry.PoolSetupArgs",
+        "internalType": "struct IGaugeControllerRegistry.PoolSetupArgs[]",
         "name": "args",
-        "type": "tuple"
+        "type": "tuple[]"
       }
     ],
-    "name": "addOrEditPool",
+    "name": "addOrEditPools",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -671,6 +727,11 @@
     "outputs": [
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -757,6 +818,62 @@
   },
   {
     "inputs": [],
+    "name": "getEpoch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IGaugeControllerRegistry.Epoch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "getEpoch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IGaugeControllerRegistry.Epoch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getLastEpoch",
     "outputs": [
       {
@@ -810,11 +927,11 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "approximateBlocksPerEpoch",
+        "name": "blocksPerEpoch",
         "type": "uint256"
       }
     ],
-    "name": "setApproximateBlocksPerEpoch",
+    "name": "setBlocksPerEpoch",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -840,7 +957,7 @@
           },
           {
             "internalType": "uint256",
-            "name": "emissionPerEpoch",
+            "name": "emission",
             "type": "uint256"
           }
         ],

--- a/abis/IGaugeControllerRegistry.json
+++ b/abis/IGaugeControllerRegistry.json
@@ -1,5 +1,27 @@
 [
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "arg",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ConfigurationError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "endHeight",
+        "type": "uint256"
+      }
+    ],
+    "name": "HeightOverflowError",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "InvalidGaugeEpochError",
     "type": "error"
@@ -113,7 +135,7 @@
         "type": "uint256"
       }
     ],
-    "name": "ApproximateBlocksPerEpochSet",
+    "name": "BlocksPerEpochSet",
     "type": "event"
   },
   {
@@ -190,6 +212,11 @@
       },
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -335,12 +362,12 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "key",
-        "type": "bytes32"
-      },
-      {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -379,12 +406,12 @@
             "type": "tuple"
           }
         ],
-        "internalType": "struct IGaugeControllerRegistry.PoolSetupArgs",
+        "internalType": "struct IGaugeControllerRegistry.PoolSetupArgs[]",
         "name": "args",
-        "type": "tuple"
+        "type": "tuple[]"
       }
     ],
-    "name": "addOrEditPool",
+    "name": "addOrEditPools",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -427,6 +454,11 @@
     "outputs": [
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",
@@ -513,6 +545,62 @@
   },
   {
     "inputs": [],
+    "name": "getEpoch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IGaugeControllerRegistry.Epoch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "epoch",
+        "type": "uint256"
+      }
+    ],
+    "name": "getEpoch",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "startBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "endBlock",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IGaugeControllerRegistry.Epoch",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getLastEpoch",
     "outputs": [
       {
@@ -566,11 +654,11 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "approximateBlocksPerEpoch",
+        "name": "blocksPerEpoch",
         "type": "uint256"
       }
     ],
-    "name": "setApproximateBlocksPerEpoch",
+    "name": "setBlocksPerEpoch",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -596,7 +684,7 @@
           },
           {
             "internalType": "uint256",
-            "name": "emissionPerEpoch",
+            "name": "emission",
             "type": "uint256"
           }
         ],

--- a/abis/ILiquidityGaugePool.json
+++ b/abis/ILiquidityGaugePool.json
@@ -352,6 +352,11 @@
       {
         "components": [
           {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
+          {
             "internalType": "string",
             "name": "name",
             "type": "string"

--- a/abis/INeptuneLegends.json
+++ b/abis/INeptuneLegends.json
@@ -2,6 +2,27 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "boundTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AlreadyBoundError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"

--- a/abis/IThrowable.json
+++ b/abis/IThrowable.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/IVoteEscrowToken.json
+++ b/abis/IVoteEscrowToken.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/IWhitelistedTransfer.json
+++ b/abis/IWhitelistedTransfer.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/IWithPausability.json
+++ b/abis/IWithPausability.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/LiquidityGaugePool.json
+++ b/abis/LiquidityGaugePool.json
@@ -37,6 +37,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -44,12 +49,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {
@@ -783,6 +783,11 @@
     "outputs": [
       {
         "components": [
+          {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
           {
             "internalType": "string",
             "name": "name",

--- a/abis/LiquidityGaugePoolReward.json
+++ b/abis/LiquidityGaugePoolReward.json
@@ -540,6 +540,11 @@
       {
         "components": [
           {
+            "internalType": "bytes32",
+            "name": "key",
+            "type": "bytes32"
+          },
+          {
             "internalType": "string",
             "name": "name",
             "type": "string"

--- a/abis/MerkleProofMinter.json
+++ b/abis/MerkleProofMinter.json
@@ -42,6 +42,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -49,12 +54,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/NeptuneLegends.json
+++ b/abis/NeptuneLegends.json
@@ -16,6 +16,27 @@
     "type": "error"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "boundTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AlreadyBoundError",
+    "type": "error"
+  },
+  {
     "inputs": [],
     "name": "AlreadyInitializedError",
     "type": "error"
@@ -48,17 +69,6 @@
     "type": "error"
   },
   {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "argument",
-        "type": "bytes32"
-      }
-    ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
     "type": "error"
@@ -77,6 +87,17 @@
       }
     ],
     "name": "InvalidAmountError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "argument",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {
@@ -531,6 +552,25 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "_boundTokenId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/abis/NeptuneLegendsState.json
+++ b/abis/NeptuneLegendsState.json
@@ -2,6 +2,27 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "boundTokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "AlreadyBoundError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"
@@ -209,6 +230,25 @@
         "internalType": "bytes32",
         "name": "",
         "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "_boundTokenId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/abis/PolicyProofMinter.json
+++ b/abis/PolicyProofMinter.json
@@ -39,17 +39,6 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "argument",
-        "type": "bytes32"
-      }
-    ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "expiredOn",
         "type": "uint256"
@@ -61,6 +50,17 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "argument",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/ProofOfPolicy.json
+++ b/abis/ProofOfPolicy.json
@@ -34,17 +34,6 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "argument",
-        "type": "bytes32"
-      }
-    ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "uint256",
         "name": "expiredOn",
         "type": "uint256"
@@ -56,6 +45,17 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "argument",
+        "type": "bytes32"
+      }
+    ],
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/ProtocolMembership.json
+++ b/abis/ProtocolMembership.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/Token.json
+++ b/abis/Token.json
@@ -37,6 +37,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -44,12 +49,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/TokenRecovery.json
+++ b/abis/TokenRecovery.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/VoteEscrowLocker.json
+++ b/abis/VoteEscrowLocker.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/VoteEscrowToken.json
+++ b/abis/VoteEscrowToken.json
@@ -37,6 +37,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -44,12 +49,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/WhitelistedTransfer.json
+++ b/abis/WhitelistedTransfer.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/abis/WithPausability.json
+++ b/abis/WithPausability.json
@@ -32,6 +32,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",
@@ -39,12 +44,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "EmptyArgumentError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InvalidArgumentError",
     "type": "error"
   },
   {

--- a/scripts/ve/pools/base-goerli.json
+++ b/scripts/ve/pools/base-goerli.json
@@ -1,0 +1,46 @@
+[
+  {
+    "key": "0x7072696d65000000000000000000000000000000000000000000000000000000",
+    "name": "Prime dApps",
+    "info": "",
+    "platformFee": 500,
+    "staking": {
+      "token": "0x905af6612b71a27311e4f3a8ee478f8913ca82c8",
+      "lockupPeriodInBlocks": "100",
+      "ratio": "2000"
+    }
+  },
+  {
+    "key": "0x706f700000000000000000000000000000000000000000000000000000000000",
+    "name": "Popular DeFi Apps",
+    "info": "",
+    "platformFee": 500,
+    "staking": {
+      "token": "0x21db27f58bfefda0a61fcca0791ed259fbe26310",
+      "lockupPeriodInBlocks": "100",
+      "ratio": "2000"
+    }
+  },
+  {
+    "key": "0x676d782d76310000000000000000000000000000000000000000000000000000",
+    "name": "GMX V1",
+    "info": "",
+    "platformFee": 500,
+    "staking": {
+      "token": "0xc6709d81f5abea48d0d593b015f7dbb191c00e39",
+      "lockupPeriodInBlocks": "100",
+      "ratio": "2000"
+    }
+  },
+  {
+    "key": "0x72646e742d763100000000000000000000000000000000000000000000000000",
+    "name": "Radiant v2",
+    "info": "",
+    "platformFee": 500,
+    "staking": {
+      "token": "0x09c9d6b1a9e499a423120c03e584edc020aeda6d",
+      "lockupPeriodInBlocks": "100",
+      "ratio": "2000"
+    }
+  }
+]

--- a/scripts/ve/pools/index.js
+++ b/scripts/ve/pools/index.js
@@ -1,0 +1,19 @@
+const baseGoerli = require('./base-goerli.json')
+
+const networks = {
+  HARDHAT: 31337,
+  ETHEREUM: 1,
+  ARBITRUM: 42161,
+  BASE_GOERLI: 84531,
+  FUJI: 43113
+}
+
+const pools = {
+  [networks.HARDHAT]: baseGoerli,
+  [networks.BASE_GOERLI]: baseGoerli,
+  [networks.FUJI]: null,
+  [networks.ETHEREUM]: null,
+  [networks.ARBITRUM]: null
+}
+
+module.exports = { pools }

--- a/scripts/ve/set-gauge.js
+++ b/scripts/ve/set-gauge.js
@@ -1,0 +1,48 @@
+const { formatEther } = require('ethers/lib/utils')
+const { ethers, network } = require('hardhat')
+const factory = require('../../specs/util/factory')
+const deployments = require('../util/deployments')
+const config = require('../config')
+const { pools } = require('./pools')
+const chalk = require('chalk')
+const toChunks = (array, size) => Array(Math.ceil(array.length / size)).fill().map((_, index) => index * size).map(begin => array.slice(begin, begin + size))
+const CHUNK_SIZE = 4
+
+const getDependencies = async (deployer, chainId) => {
+  if (chainId !== 31337) {
+    return deployments.get(chainId)
+  }
+
+  const blocksPerEpoch = config.blockTime.blocksPerEpoch[chainId]
+  const npm = await factory.deployUpgradeable('FakeToken', 'Fake NPM', 'NPM')
+  const gaugeControllerRegistry = await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm.address)
+
+  return { npm: npm.address, gaugeControllerRegistry: gaugeControllerRegistry.address }
+}
+
+const deploy = async () => {
+  const [deployer] = await ethers.getSigners()
+  const previousBalance = await deployer.getBalance()
+
+  console.log('Deployer: %s Balance: %d ETH', deployer.address, formatEther(previousBalance))
+
+  const { chainId } = network.config
+  const gauges = pools[chainId]
+
+  if (!gauges) {
+    console.log(chalk.red('Pool missing for network:', chainId))
+    return
+  }
+
+  const { gaugeControllerRegistry } = await getDependencies(deployer, chainId)
+
+  const registry = await factory.attach(deployer, gaugeControllerRegistry, 'GaugeControllerRegistry')
+
+  const chunks = toChunks(gauges, CHUNK_SIZE)
+
+  for (const chunk of chunks) {
+    await registry.addOrEditPools(chunk)
+  }
+}
+
+deploy().catch(console.error)

--- a/specs/liquidity/pool/calculate-reward.spec.js
+++ b/specs/liquidity/pool/calculate-reward.spec.js
@@ -36,7 +36,7 @@ describe('Liquidity Gauge Pool: Calculate Reward without veNpm Boost', () => {
     const { args, gaugePool } = contracts
     const candidates = [[a1, randomAmount()], [a2, randomAmount()]]
 
-    const { key, emissionPerEpoch } = args.distribution[0]
+    const { key, emission } = args.distribution[0]
 
     for (const candidate of candidates) {
       const [account, amount] = candidate
@@ -49,12 +49,12 @@ describe('Liquidity Gauge Pool: Calculate Reward without veNpm Boost', () => {
 
     const totalWeight = ethers.BigNumber.from(Enumerable.from(candidates).select(x => BigInt(x[1])).sum())
     const myWeight = ethers.BigNumber.from(candidates[1][1])
-    const emissionPerBlock = ethers.BigNumber.from(emissionPerEpoch).div(blocksPerEpoch)
+    const emissionPerBlock = ethers.BigNumber.from(emission).div(blocksPerEpoch)
     const estimated = emissionPerBlock.mul(blocksToMine).mul(myWeight).div(totalWeight)
 
     reward.should
       .be.greaterThan(0)
-      .but.also.be.lessThan(emissionPerEpoch)
+      .but.also.be.lessThan(emission)
       .which.also.equals(estimated)
   })
 })

--- a/specs/liquidity/registry/add-pool.spec.js
+++ b/specs/liquidity/registry/add-pool.spec.js
@@ -24,6 +24,7 @@ describe('Gauge Controller Registry: Add Pool', () => {
     const k = key.toBytes32('prime')
 
     const pool = {
+      key: k,
       name: 'Prime dApps',
       info: '',
       platformFee: 1000,
@@ -34,7 +35,7 @@ describe('Gauge Controller Registry: Add Pool', () => {
       }
     }
 
-    await registry.addOrEditPool(k, pool)
+    await registry.addOrEditPools([pool])
 
     const result = await registry.get(k)
 

--- a/specs/util/factory/gauge.js
+++ b/specs/util/factory/gauge.js
@@ -10,7 +10,7 @@ const setGauge = async (signer) => {
   const distribution = args.candidates.map(x => {
     return {
       key: x.key,
-      emissionPerEpoch: helper.ether(helper.getRandomNumber(20_000, 200_000))
+      emission: helper.ether(helper.getRandomNumber(20_000, 200_000))
     }
   })
 

--- a/specs/util/factory/pool.js
+++ b/specs/util/factory/pool.js
@@ -18,34 +18,28 @@ const deployPool = async (signer) => {
 
   const candidates = [{
     key: key.toBytes32('prime'),
-    pool: {
-      name: 'Prime dApps',
-      info: '',
-      platformFee: 1000,
-      staking: {
-        token: primeDappsPod.address,
-        lockupPeriodInBlocks: 10_000,
-        ratio: 2000
-      }
+    name: 'Prime dApps',
+    info: '',
+    platformFee: 1000,
+    staking: {
+      token: primeDappsPod.address,
+      lockupPeriodInBlocks: 10_000,
+      ratio: 2000
     }
   },
   {
     key: key.toBytes32('popular-defi-apps'),
-    pool: {
-      name: 'Popular DeFi Apps',
-      info: '',
-      platformFee: 1500,
-      staking: {
-        token: popularDefiAppsPod.address,
-        lockupPeriodInBlocks: 10_000,
-        ratio: 2000
-      }
+    name: 'Popular DeFi Apps',
+    info: '',
+    platformFee: 1500,
+    staking: {
+      token: popularDefiAppsPod.address,
+      lockupPeriodInBlocks: 10_000,
+      ratio: 2000
     }
   }]
 
-  for (const candidate of candidates) {
-    await registry.addOrEditPool(candidate.key, candidate.pool)
-  }
+  await registry.addOrEditPools(candidates)
 
   return { args: { candidates }, pods: { primeDappsPod, popularDefiAppsPod }, npm, veNpm, store, protocol, registry }
 }

--- a/src/fakes/FakeCxToken.sol
+++ b/src/fakes/FakeCxToken.sol
@@ -7,10 +7,10 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 contract FakeCxToken is ERC20Upgradeable {
   uint256 _expiresOn;
 
-  function initialize(string memory tokenName, string memory tokenSymbol, uint256 expiresOn) public initializer {
+  function initialize(string memory tokenName, string memory tokenSymbol, uint256 expiry) public initializer {
     super.__ERC20_init(tokenName, tokenSymbol);
 
-    _expiresOn = expiresOn;
+    _expiresOn = expiry;
   }
 
   function mint(address account, uint256 amount) external {

--- a/src/fakes/nft/FakeNeptuneLegends.sol
+++ b/src/fakes/nft/FakeNeptuneLegends.sol
@@ -90,7 +90,7 @@ contract FakeNeptuneLegends is AccessControlUpgradeable, ERC721BurnableUpgradeab
     //_throwIfSenderIsNot(DEFAULT_ADMIN_ROLE);
 
     if (bytes(baseUri).length == 0) {
-      revert EmptyArgumentError("baseUri");
+      revert InvalidArgumentError("baseUri");
     }
 
     emit BaseUriSet(super._baseURI(), baseUri);

--- a/src/gauge-pool/LiquidityGaugePoolReward.sol
+++ b/src/gauge-pool/LiquidityGaugePoolReward.sol
@@ -35,10 +35,21 @@ abstract contract LiquidityGaugePoolReward is ILiquidityGaugePool, LiquidityGaug
   }
 
   function _getTotalBlocksSinceLastReward(bytes32 key, address account) internal view returns (uint256) {
+    IGaugeControllerRegistry.Epoch memory epoch = IGaugeControllerRegistry(_registry).getEpoch();
+
     uint256 from = _poolLastRewardHeights[key][account];
+    uint256 to = block.number;
+
+    if (to > epoch.endBlock) {
+      to = epoch.endBlock;
+    }
 
     if (from == 0) {
       return 0;
+    }
+
+    if (from < epoch.startBlock) {
+      from = epoch.startBlock;
     }
 
     // Avoid underflow
@@ -46,7 +57,7 @@ abstract contract LiquidityGaugePoolReward is ILiquidityGaugePool, LiquidityGaug
       return 0;
     }
 
-    return block.number - from;
+    return to - from;
   }
 
   function _calculateReward(uint256 veBoostRatio, bytes32 key, address account) internal view returns (uint256) {

--- a/src/gauge-registry/GaugeControllerRegistryState.sol
+++ b/src/gauge-registry/GaugeControllerRegistryState.sol
@@ -19,6 +19,7 @@ abstract contract GaugeControllerRegistryState is IGaugeControllerRegistry {
   address public _rewardToken;
 
   uint256 public _epoch;
+  uint256 public _blocksPerEpoch;
   uint256 public _sumNpmDeposits;
   uint256 public _sumNpmWithdrawals;
 
@@ -28,8 +29,7 @@ abstract contract GaugeControllerRegistryState is IGaugeControllerRegistry {
   mapping(uint256 => uint256) public _gaugeAllocations;
 
   mapping(bytes32 => PoolSetupArgs) public _pools;
-
-  uint256 public _approximateBlocksPerEpoch;
+  mapping(uint256 => Epoch) public _epochs;
 }
 // slither-disable-end uninitialized-state
 // slither-disable-end unused-state

--- a/src/gauge-registry/interfaces/IGaugeControllerRegistry.sol
+++ b/src/gauge-registry/interfaces/IGaugeControllerRegistry.sol
@@ -10,6 +10,7 @@ interface IGaugeControllerRegistry {
   }
 
   struct PoolSetupArgs {
+    bytes32 key;
     string name;
     string info;
     uint256 platformFee;
@@ -18,11 +19,16 @@ interface IGaugeControllerRegistry {
 
   struct Gauge {
     bytes32 key;
-    uint256 emissionPerEpoch;
+    uint256 emission;
   }
 
-  function addOrEditPool(bytes32 key, PoolSetupArgs calldata args) external;
-  function setApproximateBlocksPerEpoch(uint256 approximateBlocksPerEpoch) external;
+  struct Epoch {
+    uint256 startBlock;
+    uint256 endBlock;
+  }
+
+  function addOrEditPools(PoolSetupArgs[] calldata args) external;
+  function setBlocksPerEpoch(uint256 blocksPerEpoch) external;
   function setGauge(uint256 epoch, uint256 amountToDeposit, Gauge[] calldata distribution) external;
   function withdrawRewards(bytes32 key, uint256 amount) external;
   function deactivatePool(bytes32 key) external;
@@ -37,8 +43,10 @@ interface IGaugeControllerRegistry {
   function getLastEpoch() external view returns (uint256);
   function getEmissionPerBlock(bytes32 key) external view returns (uint256);
   function getAllocation(uint256 epoch) external view returns (uint256);
+  function getEpoch() external view returns (Epoch memory);
+  function getEpoch(uint256 epoch) external view returns (Epoch memory);
 
-  event ApproximateBlocksPerEpochSet(uint256 previous, uint256 current);
+  event BlocksPerEpochSet(uint256 previous, uint256 current);
   event GaugeControllerRegistryOperatorSet(address previousOperator, address operator);
   event GaugeControllerRegistryRewardsWithdrawn(bytes32 key, uint256 amount);
   event GaugeControllerRegistryPoolAddedOrEdited(address indexed sender, bytes32 indexed key, PoolSetupArgs args);
@@ -48,7 +56,9 @@ interface IGaugeControllerRegistry {
   event GaugeSet(uint256 indexed epoch, bytes32 indexed key, uint256 distribution);
   event GaugeAllocationTransferred(uint256 indexed epoch, uint256 totalAllocation);
 
+  error ConfigurationError(bytes32 arg);
   error InvalidGaugeEpochError();
+  error HeightOverflowError(uint256 endHeight);
   error PoolNotFoundError(bytes32 key);
   error PoolNotActiveError(bytes32 key);
   error PoolDeactivatedError(bytes32 key);

--- a/src/nft-minter/merkle/MerkleProofMinter.sol
+++ b/src/nft-minter/merkle/MerkleProofMinter.sol
@@ -145,7 +145,7 @@ contract MerkleProofMinter is IAccessControlUtil, AccessControlUpgradeable, Paus
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   function grantRoles(AccountWithRoles[] calldata detail) external override nonReentrant whenNotPaused {
     if (detail.length == 0) {
-      revert EmptyArgumentError("detail");
+      revert InvalidArgumentError("detail");
     }
 
     for (uint256 i = 0; i < detail.length; i++) {

--- a/src/nft-minter/policy/PolicyProofMinter.sol
+++ b/src/nft-minter/policy/PolicyProofMinter.sol
@@ -58,7 +58,7 @@ contract PolicyProofMinter is IThrowable, IPolicyProofMinter, IAccessControlUtil
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
   function grantRoles(AccountWithRoles[] calldata detail) external override whenNotPaused {
     if (detail.length == 0) {
-      revert EmptyArgumentError("detail");
+      revert InvalidArgumentError("detail");
     }
 
     for (uint256 i = 0; i < detail.length; i++) {

--- a/src/nft/NeptuneLegendsState.sol
+++ b/src/nft/NeptuneLegendsState.sol
@@ -17,9 +17,11 @@ abstract contract NeptuneLegendsState is INeptuneLegends {
   bytes32 public constant NS_ROLES_RECOVERY_AGENT = "role:recovery:agent";
 
   string public _uri;
+
   mapping(address => bool) public _pausers;
   mapping(uint256 => bool) public _minted;
   mapping(uint256 => bool) public _soulbound;
+  mapping(address => uint256) public _boundTokenId;
 }
 
 // slither-disable-end uninitialized-state

--- a/src/nft/interfaces/INeptuneLegends.sol
+++ b/src/nft/interfaces/INeptuneLegends.sol
@@ -23,6 +23,7 @@ interface INeptuneLegends {
   function _soulbound(uint256 id) external view returns (bool);
 
   error SoulboundError(uint256 tokenId);
+  error AlreadyBoundError(address account, uint256 boundTokenId, uint256 tokenId);
   error AlreadyMintedError(uint256 tokenId);
   error InvalidAmountError(uint256 valid, uint256 specified);
   error OperationNotSupportedError();

--- a/src/util/interfaces/IThrowable.sol
+++ b/src/util/interfaces/IThrowable.sol
@@ -9,7 +9,7 @@ interface IThrowable {
   error ProtocolPausedError();
   error RelatedArrayItemCountMismatchError();
   error ExternalContractInvocationRevertError();
-  error EmptyArgumentError(bytes32 argument);
+  error InvalidArgumentError(bytes32 argument);
   error ZeroAmountError(bytes32 argument);
   error ZeroAddressError(bytes32 argument);
   error BalanceInsufficientError(uint256 required, uint256 provided);


### PR DESCRIPTION
- For brevity, renamed the variable `approximateBlocksPerEpoch` to `blocksPerEpoch`
- Refactored `_getTotalBlocksSinceLastReward` to account for the epoch start and end block heights
- Refactored `addOrEditPool` to become `addOrEditPools`
- Refactored the `setGauge` function to set the epoch start and end block (Epoch Info)
- Added function `getEpoch`
- Refactored NFT contract to consolidate the logic of `mint` and `mintMany`
- Refactored NFT contract to add `_boundTokenId` feature.
- Refactored ABIs