### PR TITLE
Last Epoch, Soulbound Validation, and Event Refactors

### DIFF
--- a/.openzeppelin/unknown-84531.json
+++ b/.openzeppelin/unknown-84531.json
@@ -4860,6 +4860,568 @@
           }
         }
       }
+    },
+    "dd5f4a81fd3e10fa1d4c3079690307988639ecb3f9aa24cb2433f7fae3f3ce0e": {
+      "address": "0x91ae63877a66719C0caE70687c3787ddDB0CF684",
+      "txHash": "0xf8c2fef513932294f937c7b707d9fb79e5a2ec3ee85abdca851c257577177ed7",
+      "layout": {
+        "solcVersion": "0.8.18",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_string_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:25"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_string_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:28"
+          },
+          {
+            "label": "_owners",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:34"
+          },
+          {
+            "label": "_tokenApprovals",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:37"
+          },
+          {
+            "label": "_operatorApprovals",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_uint256)44_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:517"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC721BurnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol:38"
+          },
+          {
+            "label": "_defaultRoyaltyInfo",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_struct(RoyaltyInfo)2310_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:36"
+          },
+          {
+            "label": "_tokenRoyaltyInfo",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_mapping(t_uint256,t_struct(RoyaltyInfo)2310_storage)",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:123"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "301",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_uri",
+            "offset": 0,
+            "slot": "351",
+            "type": "t_string_storage",
+            "contract": "NeptuneLegendsState",
+            "src": "src/nft/NeptuneLegendsState.sol:19"
+          },
+          {
+            "label": "_pausers",
+            "offset": 0,
+            "slot": "352",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "NeptuneLegendsState",
+            "src": "src/nft/NeptuneLegendsState.sol:21"
+          },
+          {
+            "label": "_minted",
+            "offset": 0,
+            "slot": "353",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "NeptuneLegendsState",
+            "src": "src/nft/NeptuneLegendsState.sol:22"
+          },
+          {
+            "label": "_soulbound",
+            "offset": 0,
+            "slot": "354",
+            "type": "t_mapping(t_uint256,t_bool)",
+            "contract": "NeptuneLegendsState",
+            "src": "src/nft/NeptuneLegendsState.sol:23"
+          },
+          {
+            "label": "_boundTokenId",
+            "offset": 0,
+            "slot": "355",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NeptuneLegendsState",
+            "src": "src/nft/NeptuneLegendsState.sol:24"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]",
+            "numberOfBytes": "1408"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_bool)": {
+            "label": "mapping(uint256 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(RoyaltyInfo)2310_storage)": {
+            "label": "mapping(uint256 => struct ERC2981Upgradeable.RoyaltyInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoyaltyInfo)2310_storage": {
+            "label": "struct ERC2981Upgradeable.RoyaltyInfo",
+            "members": [
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royaltyFraction",
+                "type": "t_uint96",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "a7f20cdf1938fc8868d52411b4bfd452ff66a17d5c6ee0a8fd201914b3e680eb": {
+      "address": "0x1B23EC06dF868E8819b6bE973678D5a1f28C29Ed",
+      "txHash": "0x600bf4c64ac38828dae25e3e5115b1b92878a8d79325063a7fd631cfa5588167",
+      "layout": {
+        "solcVersion": "0.8.18",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:80"
+          },
+          {
+            "label": "_nft",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_contract(INeptuneLegends)4482",
+            "contract": "MerkleProofMinterState",
+            "src": "src/nft-minter/merkle/MerkleProofMinterState.sol:17"
+          },
+          {
+            "label": "_merkleRoot",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_bytes32",
+            "contract": "MerkleProofMinterState",
+            "src": "src/nft-minter/merkle/MerkleProofMinterState.sol:19"
+          },
+          {
+            "label": "souls",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "MerkleProofMinterState",
+            "src": "src/nft-minter/merkle/MerkleProofMinterState.sol:21"
+          },
+          {
+            "label": "_personas",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_mapping(t_address,t_mapping(t_uint8,t_uint8))",
+            "contract": "MerkleProofMinterState",
+            "src": "src/nft-minter/merkle/MerkleProofMinterState.sol:24"
+          },
+          {
+            "label": "_mintStatus",
+            "offset": 0,
+            "slot": "255",
+            "type": "t_mapping(t_address,t_mapping(t_uint8,t_bool))",
+            "contract": "MerkleProofMinterState",
+            "src": "src/nft-minter/merkle/MerkleProofMinterState.sol:27"
+          },
+          {
+            "label": "_boundaries",
+            "offset": 0,
+            "slot": "256",
+            "type": "t_mapping(t_uint256,t_mapping(t_bytes32,t_struct(Boundary)4302_storage))",
+            "contract": "MerkleProofMinterState",
+            "src": "src/nft-minter/merkle/MerkleProofMinterState.sol:28"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(INeptuneLegends)4482": {
+            "label": "contract INeptuneLegends",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint8,t_bool))": {
+            "label": "mapping(address => mapping(uint8 => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint8,t_uint8))": {
+            "label": "mapping(address => mapping(uint8 => uint8))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Boundary)4302_storage)": {
+            "label": "mapping(bytes32 => struct IMerkleProofMinter.Boundary)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_bytes32,t_struct(Boundary)4302_storage))": {
+            "label": "mapping(uint256 => mapping(bytes32 => struct IMerkleProofMinter.Boundary))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint8,t_bool)": {
+            "label": "mapping(uint8 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint8,t_uint8)": {
+            "label": "mapping(uint8 => uint8)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Boundary)4302_storage": {
+            "label": "struct IMerkleProofMinter.Boundary",
+            "members": [
+              {
+                "label": "level",
+                "type": "t_uint8",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "min",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "max",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/abis/GaugeControllerRegistry.json
+++ b/abis/GaugeControllerRegistry.json
@@ -1167,6 +1167,11 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "lastEpoch",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "blocksPerEpoch",
         "type": "uint256"
       },

--- a/abis/ILiquidityGaugePool.json
+++ b/abis/ILiquidityGaugePool.json
@@ -194,7 +194,7 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "triggeredBy",
         "type": "address"

--- a/abis/IMerkleProofMinter.json
+++ b/abis/IMerkleProofMinter.json
@@ -187,6 +187,12 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
         "indexed": false,
         "internalType": "bytes32[]",
         "name": "proof",

--- a/abis/LiquidityGaugePool.json
+++ b/abis/LiquidityGaugePool.json
@@ -372,7 +372,7 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "triggeredBy",
         "type": "address"

--- a/abis/LiquidityGaugePoolReward.json
+++ b/abis/LiquidityGaugePoolReward.json
@@ -207,7 +207,7 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "address",
         "name": "triggeredBy",
         "type": "address"

--- a/abis/MerkleProofMinter.json
+++ b/abis/MerkleProofMinter.json
@@ -290,6 +290,12 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
         "indexed": false,
         "internalType": "bytes32[]",
         "name": "proof",

--- a/abis/MerkleProofMinterState.json
+++ b/abis/MerkleProofMinterState.json
@@ -187,6 +187,12 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
         "indexed": false,
         "internalType": "bytes32[]",
         "name": "proof",

--- a/scripts/deploy/nft/merkle-proof-minter-upgrade.js
+++ b/scripts/deploy/nft/merkle-proof-minter-upgrade.js
@@ -1,0 +1,16 @@
+const { formatEther } = require('ethers/lib/utils')
+const { ethers } = require('hardhat')
+const factory = require('../../../specs/util/factory')
+
+const deploy = async () => {
+  const [deployer] = await ethers.getSigners()
+  const previousBalance = await deployer.getBalance()
+
+  console.log('Deployer: %s Balance: %d ETH', deployer.address, formatEther(previousBalance))
+
+  // 0x0866f9927d94a5D7072E91DcF77E407099170Bf5
+
+  await factory.upgrade('0xd673f97cA6DC3f807E0EAA9d0271b165C2A6d657', 'NeptuneLegends', 'https://nft.neptunemutual.net/metadata/', deployer.address, deployer.address)
+}
+
+deploy().catch(console.error)

--- a/scripts/deploy/nft/neptune-legends-upgrade.js
+++ b/scripts/deploy/nft/neptune-legends-upgrade.js
@@ -1,0 +1,28 @@
+const { formatEther } = require('ethers/lib/utils')
+const { ethers, network } = require('hardhat')
+const factory = require('../../../specs/util/factory')
+const deployments = require('../../util/deployments')
+
+const getDependencies = async (deployer, chainId) => {
+  if (chainId !== 31337) {
+    return deployments.get(chainId)
+  }
+
+  const neptuneLegends = await factory.deployUpgradeable('NeptuneLegends', 'https://nft.neptunemutual.net/metadata/', deployer.address, deployer.address)
+  return { neptuneLegends: neptuneLegends.address }
+}
+
+const deploy = async () => {
+  const [deployer] = await ethers.getSigners()
+  const previousBalance = await deployer.getBalance()
+  const { chainId } = network.config
+
+  console.log('Deployer: %s Balance: %d ETH', deployer.address, formatEther(previousBalance))
+
+  // const { neptuneLegends } = getDependencies(deployer, chainId)
+  // console.log(neptuneLegends)
+  // process.exit(1)
+  await factory.upgrade('0xd673f97cA6DC3f807E0EAA9d0271b165C2A6d657', 'NeptuneLegends', 'https://nft.neptunemutual.net/metadata/', deployer.address, deployer.address)
+}
+
+deploy().catch(console.error)

--- a/scripts/deploy/ve/gauge-controller-registry-deploy.js
+++ b/scripts/deploy/ve/gauge-controller-registry-deploy.js
@@ -26,11 +26,11 @@ const deploy = async () => {
   const blocksPerEpoch = config.blockTime.blocksPerEpoch[chainId]
 
   if (!gaugeControllerRegistry) {
-    await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm)
+    await factory.deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm)
     return
   }
 
-  await factory.upgrade(gaugeControllerRegistry, 'GaugeControllerRegistry', blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm)
+  await factory.upgrade(gaugeControllerRegistry, 'GaugeControllerRegistry', 0, blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm)
 }
 
 deploy().catch(console.error)

--- a/scripts/deploy/ve/liquidity-gauge.js
+++ b/scripts/deploy/ve/liquidity-gauge.js
@@ -14,7 +14,7 @@ const getDependencies = async (chainId) => {
 
   const npm = await factory.deployUpgradeable('FakeToken', 'Fake NPM', 'NPM')
   const veNPM = await factory.deployUpgradeable('VoteEscrowToken', deployer.address, npm.address, deployer.address, 'Vote Escrow NPM', 'veNPM')
-  const gaugeControllerRegistry = await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm.address)
+  const gaugeControllerRegistry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm.address)
 
   return { npm: npm.address, veNPM: veNPM.address, gaugeControllerRegistry: gaugeControllerRegistry.address }
 }

--- a/scripts/util/deployments.js
+++ b/scripts/util/deployments.js
@@ -5,7 +5,10 @@ const get = async (chainId) => {
     return null
   }
 
-  return deployments[chainId]
+  console.log(chainId)
+  console.log(deployments, deployments[chainId.toString()])
+
+  return deployments[chainId.toString()]
 }
 
 module.exports = { get }

--- a/scripts/ve/set-gauge.js
+++ b/scripts/ve/set-gauge.js
@@ -15,7 +15,7 @@ const getDependencies = async (deployer, chainId) => {
 
   const blocksPerEpoch = config.blockTime.blocksPerEpoch[chainId]
   const npm = await factory.deployUpgradeable('FakeToken', 'Fake NPM', 'NPM')
-  const gaugeControllerRegistry = await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm.address)
+  const gaugeControllerRegistry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, deployer.address, deployer.address, [deployer.address], npm.address)
 
   return { npm: npm.address, gaugeControllerRegistry: gaugeControllerRegistry.address }
 }

--- a/specs/liquidity/registry/add-pool.spec.js
+++ b/specs/liquidity/registry/add-pool.spec.js
@@ -17,7 +17,7 @@ describe('Gauge Controller Registry: Add Pool', () => {
     const blocksPerEpoch = config.blockTime.blocksPerEpoch[chainId]
 
     contracts = await factory.deployProtocol(owner)
-    registry = await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, owner.address, owner.address, [owner.address], contracts.npm.address)
+    registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, owner.address, owner.address, [owner.address], contracts.npm.address)
   })
 
   it('must correctly add a new pool', async () => {

--- a/specs/liquidity/registry/ctor.spec.js
+++ b/specs/liquidity/registry/ctor.spec.js
@@ -16,7 +16,7 @@ describe('Gauge Controller Registry: Constructor', () => {
     const blocksPerEpoch = config.blockTime.blocksPerEpoch[chainId]
 
     npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
-    registry = await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, owner.address, owner.address, [owner.address], npm.address)
+    registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, owner.address, owner.address, [owner.address], npm.address)
   })
 
   it('must correctly set the state upon construction', async () => {

--- a/specs/liquidity/registry/set-gauge.spec.js
+++ b/specs/liquidity/registry/set-gauge.spec.js
@@ -41,7 +41,7 @@ describe('Gauge Controller Registry: Set Gauge', () => {
 
     contracts = await factory.deployProtocol(owner)
 
-    registry = await factory.deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, owner.address, owner.address, [owner.address], contracts.npm.address)
+    registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, owner.address, owner.address, [owner.address], contracts.npm.address)
 
     await registry.addOrEditPools(candidates)
   })

--- a/specs/util/factory/pool.js
+++ b/specs/util/factory/pool.js
@@ -14,7 +14,7 @@ const deployPool = async (signer) => {
   const popularDefiAppsPod = await deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-POP')
 
   const veNpm = await deployUpgradeable('VoteEscrowToken', signer.address, npm.address, signer.address, 'Vote Escrow NPM', 'veNPM')
-  const registry = await deployUpgradeable('GaugeControllerRegistry', blocksPerEpoch, signer.address, signer.address, [signer.address], npm.address)
+  const registry = await deployUpgradeable('GaugeControllerRegistry', 0, blocksPerEpoch, signer.address, signer.address, [signer.address], npm.address)
 
   const candidates = [{
     key: key.toBytes32('prime'),

--- a/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
+++ b/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
@@ -13,7 +13,7 @@ interface ILiquidityGaugePool {
   function calculateReward(bytes32 key, address account) external view returns (uint256);
   function getTotalBlocksSinceLastReward(bytes32 key, address account) external view returns (uint256);
 
-  event VotingPowersUpdated(address triggeredBy, uint256 previous, uint256 current, uint256 previousTotal, uint256 currentTotal);
+  event VotingPowersUpdated(address indexed triggeredBy, uint256 previous, uint256 current, uint256 previousTotal, uint256 currentTotal);
   event LiquidityGaugeRewardsWithdrawn(bytes32 indexed key, address indexed account, address treasury, uint256 rewards, uint256 platformFee);
   event LiquidityGaugeDeposited(bytes32 indexed key, address indexed account, address indexed stakingToken, uint256 amount);
   event LiquidityGaugeWithdrawn(bytes32 indexed key, address indexed account, address indexed stakingToken, uint256 amount);

--- a/src/gauge-registry/GaugeControllerRegistry.sol
+++ b/src/gauge-registry/GaugeControllerRegistry.sol
@@ -23,7 +23,7 @@ contract GaugeControllerRegistry is AccessControlUpgradeable, PausableUpgradeabl
     return 10_000;
   }
 
-  function initialize(uint256 blocksPerEpoch, address admin, address gaugeAgent, address[] calldata pausers, address rewardToken) external initializer {
+  function initialize(uint256 lastEpoch, uint256 blocksPerEpoch, address admin, address gaugeAgent, address[] calldata pausers, address rewardToken) external initializer {
     super.__AccessControl_init();
     super.__Pausable_init();
 
@@ -43,6 +43,7 @@ contract GaugeControllerRegistry is AccessControlUpgradeable, PausableUpgradeabl
       revert InvalidArgumentError("rewardToken");
     }
 
+    _epoch = lastEpoch;
     _rewardToken = rewardToken;
     _blocksPerEpoch = blocksPerEpoch;
 

--- a/src/nft-minter/merkle/MerkleProofMinter.sol
+++ b/src/nft-minter/merkle/MerkleProofMinter.sol
@@ -65,7 +65,7 @@ contract MerkleProofMinter is IAccessControlUtil, AccessControlUpgradeable, Paus
     _mintStatus[_msgSender()][level] = true;
     _nft.mint(_getMintInfo(tokenId, _msgSender()));
 
-    emit MintedWithProof(proof, level, tokenId);
+    emit MintedWithProof(_msgSender(), proof, level, tokenId);
   }
 
   function validate(uint256 boundTokenId, uint8 level, bytes32 family, uint8 persona, uint256 tokenId) public view {
@@ -185,7 +185,7 @@ contract MerkleProofMinter is IAccessControlUtil, AccessControlUpgradeable, Paus
 
     info.sendTo = account;
     info.id = tokenId;
-    info.soulbound = true;
+    info.soulbound = false;
 
     return info;
   }

--- a/src/nft-minter/merkle/interfaces/IMerkleProofMinter.sol
+++ b/src/nft-minter/merkle/interfaces/IMerkleProofMinter.sol
@@ -13,7 +13,7 @@ interface IMerkleProofMinter {
 
   event MerkleRootSet(address indexed account, bytes32 previous, bytes32 current);
   event BoundariesSet(address indexed account, uint256[] levels, Boundary[] boundaries);
-  event MintedWithProof(bytes32[] proof, uint256 level, uint256 tokenId);
+  event MintedWithProof(address indexed account, bytes32[] proof, uint256 level, uint256 tokenId);
   event PersonaSet(address indexed account, uint8 level, uint8 persona);
 
   error InvalidBindingError(address account, uint256 boundTokenId);

--- a/src/nft/NeptuneLegends.sol
+++ b/src/nft/NeptuneLegends.sol
@@ -69,7 +69,7 @@ contract NeptuneLegends is AccessControlUpgradeable, ERC721BurnableUpgradeable, 
       revert AlreadyMintedError(info.id);
     }
 
-    if (_boundTokenId[info.sendTo] > 0) {
+    if (_boundTokenId[info.sendTo] > 0 && info.soulbound == true) {
       revert AlreadyBoundError(info.sendTo, _boundTokenId[info.sendTo], info.id);
     }
 
@@ -77,10 +77,11 @@ contract NeptuneLegends is AccessControlUpgradeable, ERC721BurnableUpgradeable, 
     _minted[info.id] = true;
 
     if (info.soulbound) {
+      _boundTokenId[info.sendTo] = info.id;
+
       emit SoulBound(info.id);
     }
 
-    _boundTokenId[info.sendTo] = info.id;
     super._safeMint(info.sendTo, info.id, "");
   }
 


### PR DESCRIPTION
- Indexed the argument `triggeredBy` on the event `VotingPowersUpdated`
- Added `lastEpoch` parameter to `GaugeControllerRegistry` initializer
- Added validation on the `mint` function of `NeptuneLegends` to ensure that an account can only mint a single soul bound NFT
- Added parameter `account` to the `MintedWithProof` event of `IMerkleProofMinter` contract
- Updated ABIs