### PR TITLE
Added tests for vote escrow and gauge pools

### DIFF
--- a/specs/escrow/boost/get-voting-power.spec.js
+++ b/specs/escrow/boost/get-voting-power.spec.js
@@ -24,9 +24,7 @@ describe('Vote Escrow Token: getVotingPower', () => {
 
     const [owner, account2] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
-
-    contracts.veNpm = veNpm
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
 
     await contracts.npm.mint(owner.address, amounts[0])
     await contracts.npm.mint(account2.address, amounts[1])

--- a/specs/escrow/ctor.spec.js
+++ b/specs/escrow/ctor.spec.js
@@ -13,9 +13,7 @@ describe('Vote Escrow Token: Constructor', () => {
 
     const [owner] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
-
-    contracts.veNpm = veNpm
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
   })
 
   it('must correctly set the state upon construction', async () => {

--- a/specs/escrow/lock/lock.extension.spec.js
+++ b/specs/escrow/lock/lock.extension.spec.js
@@ -17,9 +17,7 @@ describe('Vote Escrow Token: lock', () => {
 
     const [owner] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
-
-    contracts.veNpm = veNpm
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
   })
 
   it('must correctly extend existing locks', async () => {

--- a/specs/escrow/lock/lock.spec.js
+++ b/specs/escrow/lock/lock.spec.js
@@ -18,29 +18,27 @@ describe('Vote Escrow Token: lock', () => {
 
     const [owner] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
-
-    contracts.veNpm = veNpm
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
   })
 
   it('must successfully lock NPM tokens', async () => {
-    const [owner, account2] = await ethers.getSigners()
+    const [owner, bob] = await ethers.getSigners()
     const amounts = [helper.ether(20_000), helper.ether(50_000)]
     const durations = [10, 20]
     const heights = []
     const timestamps = []
 
     await contracts.npm.mint(owner.address, amounts[0])
-    await contracts.npm.mint(account2.address, amounts[1])
+    await contracts.npm.mint(bob.address, amounts[1])
 
     await contracts.npm.approve(contracts.veNpm.address, amounts[0])
-    await contracts.npm.connect(account2).approve(contracts.veNpm.address, amounts[1])
+    await contracts.npm.connect(bob).approve(contracts.veNpm.address, amounts[1])
 
     await contracts.veNpm.lock(amounts[0], durations[0]).should.not.be.rejected
     heights.push(await ethers.provider.getBlockNumber())
     timestamps.push(await time.latest())
 
-    await contracts.veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
+    await contracts.veNpm.connect(bob).lock(amounts[1], durations[1]).should.not.be.rejected
     heights.push(await ethers.provider.getBlockNumber())
     timestamps.push(await time.latest())
 
@@ -50,8 +48,24 @@ describe('Vote Escrow Token: lock', () => {
     ;(await contracts.veNpm._unlockAt(owner.address)).should.equal(timestamps[0] + (durations[0] * WEEKS))
     ;(await contracts.veNpm._minUnlockHeights(owner.address)).should.equal(heights[0] + MIN_LOCK_HEIGHT)
 
-    ;(await contracts.veNpm._balances(account2.address)).should.equal(amounts[1])
-    ;(await contracts.veNpm._unlockAt(account2.address)).should.equal(timestamps[1] + (durations[1] * WEEKS))
-    ;(await contracts.veNpm._minUnlockHeights(account2.address)).should.equal(heights[1] + MIN_LOCK_HEIGHT)
+    ;(await contracts.veNpm._balances(bob.address)).should.equal(amounts[1])
+    ;(await contracts.veNpm._unlockAt(bob.address)).should.equal(timestamps[1] + (durations[1] * WEEKS))
+    ;(await contracts.veNpm._minUnlockHeights(bob.address)).should.equal(heights[1] + MIN_LOCK_HEIGHT)
+  })
+
+  it('must not allow to lock NPM tokens when paused', async () => {
+    const [, bob] = await ethers.getSigners()
+    const amounts = [helper.ether(20_000), helper.ether(50_000)]
+    const durations = [10, 20]
+
+    // Set `bob` as pauser
+    await contracts.veNpm.setPausers([bob.address], [true])
+    await contracts.veNpm.connect(bob).pause()
+
+    await contracts.veNpm.lock(amounts[0], durations[0])
+      .should.be.rejectedWith('Pausable: paused')
+
+    await contracts.veNpm.unpause()
+    await contracts.veNpm.setPausers([bob.address], [false])
   })
 })

--- a/specs/escrow/pausable/pause.spec.js
+++ b/specs/escrow/pausable/pause.spec.js
@@ -1,0 +1,44 @@
+const factory = require('../../util/factory')
+const helper = require('../../util/key')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: Pause/Unpause', () => {
+  let contracts, name, symbol
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner, bob] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
+
+    const pausers = [bob.address]
+    const statuses = [true]
+
+    await contracts.veNpm.setPausers(pausers, statuses)
+  })
+
+  it('must allow pausers to pause', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.veNpm.connect(bob).pause()
+    await contracts.veNpm.unpause()
+  })
+
+  it('must not allow non pausers to pause', async () => {
+    await contracts.veNpm.pause()
+      .should.be.revertedWithCustomError(contracts.veNpm, 'AccessDeniedError')
+      .withArgs(helper.toBytes32('Pauser'))
+  })
+
+  it('must not allow non owners to unpause', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.veNpm.connect(bob).unpause()
+      .should.be.rejectedWith('Ownable: caller is not the owner')
+  })
+})

--- a/specs/escrow/pausable/set-pausers.spec.js
+++ b/specs/escrow/pausable/set-pausers.spec.js
@@ -13,9 +13,7 @@ describe('Vote Escrow Token: setPausers', () => {
 
     const [owner] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
-
-    contracts.veNpm = veNpm
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
   })
 
   it('must correctly set pausers', async () => {

--- a/specs/escrow/recover.spec.js
+++ b/specs/escrow/recover.spec.js
@@ -1,0 +1,97 @@
+const factory = require('../util/factory')
+const { forceSendEther } = require('../util/factory/force-ether')
+const helper = require('../util/helper')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Vote Escrow Token: Recover Token', () => {
+  let contracts, name, symbol
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
+    contracts.weth = await factory.deployUpgradeable('FakeToken', 'Wrapped ETH', 'WETH')
+  })
+
+  it('must allow recovering tokens', async () => {
+    const [owner] = await ethers.getSigners()
+
+    await contracts.weth.mint(owner.address, helper.ether(100_000_000))
+    const receiver = helper.randomAddress()
+
+    await contracts.weth.transfer(contracts.veNpm.address, helper.ether(12340))
+    await contracts.veNpm.recoverToken(contracts.weth.address, receiver)
+
+    const balance = await contracts.weth.balanceOf(receiver)
+    balance.should.equal(helper.ether(12340))
+  })
+
+  it('must not throw when contract token balance is zero', async () => {
+    const receiver = helper.randomAddress()
+
+    await contracts.veNpm.recoverToken(contracts.weth.address, receiver)
+      .should.not.be.rejected
+
+    const balance = await contracts.weth.balanceOf(receiver)
+    balance.should.equal(helper.ether('0'))
+  })
+
+  it('must not allow non owners to recover tokens', async () => {
+    const [, , charlie] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.veNpm.connect(charlie).recoverToken(contracts.weth.address, receiver)
+      .should.be.rejectedWith('Ownable: caller is not the owner')
+  })
+})
+
+describe('Vote Escrow Token: Recover Ether', () => {
+  let contracts, name, symbol
+
+  before(async () => {
+    name = 'Vote Escrow NPM'
+    symbol = 'veNPM'
+
+    const [owner] = await ethers.getSigners()
+    contracts = await factory.deployProtocol(owner)
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
+    contracts.weth = await factory.deployUpgradeable('FakeToken', 'Wrapped ETH', 'WETH')
+  })
+
+  it('must allow recovering ether', async () => {
+    const [owner] = await ethers.getSigners()
+
+    await forceSendEther(contracts.veNpm.address, owner)
+    const receiver = helper.randomAddress()
+
+    await contracts.veNpm.recoverEther(receiver)
+
+    const balance = await owner.provider.getBalance(receiver)
+    balance.should.equal(helper.ether(1))
+  })
+
+  it('must not throw when contract ether balance is zero', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.veNpm.recoverEther(receiver)
+      .should.not.be.rejected
+
+    const balance = await bob.provider.getBalance(receiver)
+    balance.should.equal(helper.ether('0'))
+  })
+
+  it('must not allow non owners to recover ether', async () => {
+    const [, , charlie] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.veNpm.connect(charlie).recoverEther(receiver)
+      .should.be.rejectedWith('Ownable: caller is not the owner')
+  })
+})

--- a/specs/escrow/unlock/unlock-prematurely.spec.js
+++ b/specs/escrow/unlock/unlock-prematurely.spec.js
@@ -18,9 +18,9 @@ describe('Vote Escrow Token: unlock', () => {
 
     const [owner, account1, account2] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
 
-    await contracts.store.setBool(key.qualifyMember(veNpm.address), true)
+    await contracts.store.setBool(key.qualifyMember(contracts.veNpm.address), true)
 
     amounts = [helper.ether(20_000), helper.ether(50_000)]
     durations = [10, 20]
@@ -28,13 +28,12 @@ describe('Vote Escrow Token: unlock', () => {
     await contracts.npm.mint(account1.address, amounts[0])
     await contracts.npm.mint(account2.address, amounts[1])
 
-    await contracts.npm.connect(account1).approve(veNpm.address, amounts[0])
-    await contracts.npm.connect(account2).approve(veNpm.address, amounts[1])
+    await contracts.npm.connect(account1).approve(contracts.veNpm.address, amounts[0])
+    await contracts.npm.connect(account2).approve(contracts.veNpm.address, amounts[1])
 
-    await veNpm.connect(account1).lock(amounts[0], durations[0]).should.not.be.rejected
-    await veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
+    await contracts.veNpm.connect(account1).lock(amounts[0], durations[0]).should.not.be.rejected
+    await contracts.veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
 
-    contracts.veNpm = veNpm
     await mine(MIN_LOCK_HEIGHT)
   })
 
@@ -53,7 +52,7 @@ describe('Vote Escrow Token: unlock', () => {
 
       const balance = await contracts.npm.balanceOf(account.address)
       balance.should.equal((amounts[i] * (100n - PENALTY_RATE)) / 100n)
-      fees +=  (amounts[i] * PENALTY_RATE) / 100n
+      fees += (amounts[i] * PENALTY_RATE) / 100n
     }
 
     const [owner] = signers

--- a/specs/escrow/unlock/unlock.spec.js
+++ b/specs/escrow/unlock/unlock.spec.js
@@ -16,9 +16,9 @@ describe('Vote Escrow Token: unlock', () => {
 
     const [owner, account2] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
 
-    await contracts.store.setBool(key.qualifyMember(veNpm.address), true)
+    await contracts.store.setBool(key.qualifyMember(contracts.veNpm.address), true)
 
     amounts = [helper.ether(20_000), helper.ether(50_000)]
     durations = [10, 20]
@@ -26,13 +26,11 @@ describe('Vote Escrow Token: unlock', () => {
     await contracts.npm.mint(owner.address, amounts[0])
     await contracts.npm.mint(account2.address, amounts[1])
 
-    await contracts.npm.approve(veNpm.address, amounts[0])
-    await contracts.npm.connect(account2).approve(veNpm.address, amounts[1])
+    await contracts.npm.approve(contracts.veNpm.address, amounts[0])
+    await contracts.npm.connect(account2).approve(contracts.veNpm.address, amounts[1])
 
-    await veNpm.lock(amounts[0], durations[0]).should.not.be.rejected
-    await veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
-
-    contracts.veNpm = veNpm
+    await contracts.veNpm.lock(amounts[0], durations[0]).should.not.be.rejected
+    await contracts.veNpm.connect(account2).lock(amounts[1], durations[1]).should.not.be.rejected
   })
 
   it('must allow unlocking as soon as the lock period is over', async () => {

--- a/specs/escrow/upgrade.spec.js
+++ b/specs/escrow/upgrade.spec.js
@@ -15,9 +15,7 @@ describe('Vote Escrow Token: Upgradeability', () => {
 
     const [owner] = await ethers.getSigners()
     contracts = await factory.deployProtocol(owner)
-    const veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
-
-    contracts.veNpm = veNpm
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, name, symbol)
   })
 
   it('must correctly set the state upon construction', async () => {

--- a/specs/util/factory/force-ether.js
+++ b/specs/util/factory/force-ether.js
@@ -1,0 +1,22 @@
+const factory = require('./index')
+const helper = require('../helper')
+
+const forceSendEther = async (toAddress, signer) => {
+  // Send eth to `toAddress` using `destruct` on ForceEther contract
+  const forceEther = await factory.deploy('ForceEther')
+  await signer.sendTransaction({
+    to: forceEther.address,
+    value: helper.ether(1)
+  })
+
+  let balance = await signer.provider.getBalance(forceEther.address)
+  balance.should.equal(helper.ether(1))
+
+  await forceEther.destruct(toAddress)
+  balance = await signer.provider.getBalance(toAddress)
+  balance.should.equal(helper.ether(1))
+}
+
+module.exports = {
+  forceSendEther
+}

--- a/specs/ve/gauge-pool/ctor.spec.js
+++ b/specs/ve/gauge-pool/ctor.spec.js
@@ -47,8 +47,13 @@ describe('Liquidity Gauge Pool: Constructor', () => {
 
     const _info = await contracts.gaugePool._poolInfo()
 
+    _info.key.should.equal(info.key)
+    _info.name.should.equal(info.name)
+    _info.info.should.equal(info.info)
+    _info.lockupPeriodInBlocks.should.equal(info.lockupPeriodInBlocks)
     _info.epochDuration.should.equal(28 * DAYS)
     _info.veBoostRatio.should.equal(1000)
+    _info.platformFee.should.equal(info.platformFee)
     _info.stakingToken.should.equal(contracts.fakePod.address)
     _info.veToken.should.equal(contracts.veNpm.address)
     _info.rewardToken.should.equal(contracts.npm.address)

--- a/specs/ve/gauge-pool/ctor.spec.js
+++ b/specs/ve/gauge-pool/ctor.spec.js
@@ -60,4 +60,11 @@ describe('Liquidity Gauge Pool: Constructor', () => {
     _info.registry.should.equal(contracts.fakeRegistry.address)
     _info.treasury.should.equal(info.treasury)
   })
+
+  it('must not allow to be initialized twice', async () => {
+    const [owner] = await ethers.getSigners()
+
+    await contracts.gaugePool.initialize(owner.address, info)
+      .should.be.rejectedWith('Initializable: contract is already initialized')
+  })
 })

--- a/specs/ve/gauge-pool/deposit.spec.js
+++ b/specs/ve/gauge-pool/deposit.spec.js
@@ -1,0 +1,83 @@
+const factory = require('../../util/factory')
+const key = require('../../util/key')
+const helper = require('../../util/helper')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Liquidity Gauge Pool: Deposit', () => {
+  let contracts, info
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+    await contracts.registry.addOrEditPools([contracts.gaugePool.address])
+
+    const emission = helper.ether(100_00)
+    const distribution = [{ key: info.key, emission }]
+    await contracts.npm.mint(owner.address, emission)
+    await contracts.npm.approve(contracts.registry.address, emission)
+    await contracts.registry.setGauge(1, emission, 28 * DAYS, distribution)
+  })
+
+  it('must allow depositing staking tokens', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+
+    await contracts.gaugePool.deposit(amountToDeposit)
+  })
+
+  it('must not allow depositing when paused', async () => {
+    const [owner, bob] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    const pauserRole = await contracts.gaugePool.NS_ROLES_PAUSER()
+    await contracts.gaugePool.grantRole(pauserRole, bob.address)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+
+    await contracts.gaugePool.connect(bob).pause()
+    await contracts.gaugePool.deposit(amountToDeposit)
+      .should.be.rejectedWith('Pausable: paused')
+
+    await contracts.gaugePool.unpause()
+  })
+
+  it('must not allow depositing 0 tokens', async () => {
+    const amountToDeposit = 0
+
+    await contracts.gaugePool.deposit(amountToDeposit)
+      .should.be.revertedWithCustomError(contracts.gaugePool, 'ZeroAmountError')
+      .withArgs(key.toBytes32('amount'))
+  })
+})

--- a/specs/ve/gauge-pool/exit.spec.js
+++ b/specs/ve/gauge-pool/exit.spec.js
@@ -1,0 +1,80 @@
+const factory = require('../../util/factory')
+const key = require('../../util/key')
+const helper = require('../../util/helper')
+const { mine } = require('@nomicfoundation/hardhat-network-helpers')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Liquidity Gauge Pool: Exit', () => {
+  let contracts, info
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+    await contracts.registry.addOrEditPools([contracts.gaugePool.address])
+
+    const emission = helper.ether(100_00)
+    const distribution = [{ key: info.key, emission }]
+    await contracts.npm.mint(owner.address, emission)
+    await contracts.npm.approve(contracts.registry.address, emission)
+    await contracts.registry.setGauge(1, emission, 28 * DAYS, distribution)
+  })
+
+  it('must allow to exit', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+
+    const balanceBeforeDeposit = await contracts.fakePod.balanceOf(owner.address)
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks)
+
+    await contracts.gaugePool.exit()
+    const balanceAfterExit = await contracts.fakePod.balanceOf(owner.address)
+    balanceAfterExit.should.equal(balanceBeforeDeposit)
+  })
+
+  it('must not allow to exit before lockup period ends', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks / 2)
+
+    await contracts.gaugePool.exit()
+      .should.be.rejectedWith('WithdrawalLockedError')
+  })
+})

--- a/specs/ve/gauge-pool/pause.spec.js
+++ b/specs/ve/gauge-pool/pause.spec.js
@@ -1,0 +1,134 @@
+const factory = require('../../util/factory')
+const key = require('../../util/key')
+const helper = require('../../util/helper')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Liquidity Gauge Pool: Pause', () => {
+  let contracts, info, pauserRole
+
+  before(async () => {
+    const [owner, bob] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+
+    pauserRole = await contracts.gaugePool.NS_ROLES_PAUSER()
+    await contracts.gaugePool.grantRole(pauserRole, bob.address)
+  })
+
+  it('must allow to be paused by pauser', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.gaugePool.connect(bob).pause()
+
+    const isPaused = await contracts.gaugePool.paused()
+    isPaused.should.equal(true)
+
+    await contracts.gaugePool.unpause()
+  })
+
+  it('must not allow to be paused by other than pauser', async () => {
+    const [owner] = await ethers.getSigners()
+
+    await contracts.gaugePool.pause()
+      .should.be.rejectedWith(`AccessControl: account ${owner.address.toLowerCase()} is missing role ${pauserRole}`)
+  })
+})
+
+describe('Liquidity Gauge Pool: Unpause', () => {
+  let contracts, info, pauserRole, adminRole
+
+  before(async () => {
+    const [owner, bob, charlie] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+
+    pauserRole = await contracts.gaugePool.NS_ROLES_PAUSER()
+    adminRole = await contracts.gaugePool.DEFAULT_ADMIN_ROLE()
+    await contracts.gaugePool.grantRole(pauserRole, bob.address)
+    await contracts.gaugePool.grantRole(adminRole, charlie.address)
+  })
+
+  it('must allow to be unpaused by owner', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.gaugePool.connect(bob).pause()
+
+    let isPaused = await contracts.gaugePool.paused()
+    isPaused.should.equal(true)
+
+    await contracts.gaugePool.unpause()
+    isPaused = await contracts.gaugePool.paused()
+    isPaused.should.equal(false)
+  })
+
+  it('must allow to be unpaused by admin', async () => {
+    const [, bob, charlie] = await ethers.getSigners()
+
+    await contracts.gaugePool.connect(bob).pause()
+
+    let isPaused = await contracts.gaugePool.paused()
+    isPaused.should.equal(true)
+
+    await contracts.gaugePool.connect(charlie).unpause()
+    isPaused = await contracts.gaugePool.paused()
+    isPaused.should.equal(false)
+  })
+
+  it('must not allow to be unpaused by other than admin', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.gaugePool.connect(bob).pause()
+
+    await contracts.gaugePool.connect(bob).unpause()
+      .should.be.rejectedWith(`AccessControl: account ${bob.address.toLowerCase()} is missing role ${adminRole}`)
+
+    await contracts.gaugePool.unpause()
+  })
+})

--- a/specs/ve/gauge-pool/recover.spec.js
+++ b/specs/ve/gauge-pool/recover.spec.js
@@ -1,0 +1,160 @@
+const factory = require('../../util/factory')
+const key = require('../../util/key')
+const helper = require('../../util/helper')
+const { forceSendEther } = require('../../util/factory/force-ether')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Liquidity Gauge Pool: Recover Token', () => {
+  let contracts, info
+
+  before(async () => {
+    const [owner, bob] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.weth = await factory.deployUpgradeable('FakeToken', 'Wrapped ETH', 'WETH')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+    await contracts.registry.addOrEditPools([contracts.gaugePool.address])
+
+    const emission = helper.ether(100_00)
+    const distribution = [{ key: info.key, emission }]
+    await contracts.npm.mint(owner.address, emission)
+    await contracts.npm.approve(contracts.registry.address, emission)
+    await contracts.registry.setGauge(1, emission, 28 * DAYS, distribution)
+
+    // Make bob recovery agent
+    const recoveryAgentRole = await contracts.gaugePool.NS_ROLES_RECOVERY_AGENT()
+    await contracts.gaugePool.grantRole(recoveryAgentRole, bob.address)
+  })
+
+  it('must allow recovering tokens', async () => {
+    const [owner, bob] = await ethers.getSigners()
+
+    await contracts.weth.mint(owner.address, helper.ether(100_000_000))
+    const receiver = helper.randomAddress()
+
+    await contracts.weth.transfer(contracts.gaugePool.address, helper.ether(12340))
+    await contracts.gaugePool.connect(bob).recoverToken(contracts.weth.address, receiver)
+
+    const balance = await contracts.weth.balanceOf(receiver)
+    balance.should.equal(helper.ether(12340))
+  })
+
+  it('must not throw when contract token balance is zero', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.gaugePool.connect(bob).recoverToken(contracts.weth.address, receiver)
+      .should.not.be.rejected
+
+    const balance = await contracts.weth.balanceOf(receiver)
+    balance.should.equal(helper.ether('0'))
+  })
+
+  it('must not allow non recovery agents to recover tokens', async () => {
+    const [, , charlie] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    const recoveryAgentRole = await contracts.gaugePool.NS_ROLES_RECOVERY_AGENT()
+    await contracts.gaugePool.connect(charlie).recoverToken(contracts.weth.address, receiver)
+      .should.be.rejectedWith(`AccessControl: account ${charlie.address.toLowerCase()} is missing role ${recoveryAgentRole}`)
+  })
+})
+
+describe('Liquidity Gauge Pool: Recover Ether', () => {
+  let contracts, info
+
+  before(async () => {
+    const [owner, bob] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+    await contracts.registry.addOrEditPools([contracts.gaugePool.address])
+
+    const emission = helper.ether(100_00)
+    const distribution = [{ key: info.key, emission }]
+    await contracts.npm.mint(owner.address, emission)
+    await contracts.npm.approve(contracts.registry.address, emission)
+    await contracts.registry.setGauge(1, emission, 28 * DAYS, distribution)
+
+    // Make bob recovery agent
+    const recoveryAgentRole = await contracts.gaugePool.NS_ROLES_RECOVERY_AGENT()
+    await contracts.gaugePool.grantRole(recoveryAgentRole, bob.address)
+  })
+
+  it('must allow recovering ether', async () => {
+    const [owner, bob] = await ethers.getSigners()
+
+    await forceSendEther(contracts.gaugePool.address, owner)
+    const receiver = helper.randomAddress()
+
+    await contracts.gaugePool.connect(bob).recoverEther(receiver)
+
+    const balance = await owner.provider.getBalance(receiver)
+    balance.should.equal(helper.ether(1))
+  })
+
+  it('must not throw when contract ether balance is zero', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.gaugePool.connect(bob).recoverEther(receiver)
+      .should.not.be.rejected
+
+    const balance = await bob.provider.getBalance(receiver)
+    balance.should.equal(helper.ether('0'))
+  })
+
+  it('must not allow non recovery agents to recover ether', async () => {
+    const [, , charlie] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    const recoveryAgentRole = await contracts.gaugePool.NS_ROLES_RECOVERY_AGENT()
+    await contracts.gaugePool.connect(charlie).recoverEther(receiver)
+      .should.be.rejectedWith(`AccessControl: account ${charlie.address.toLowerCase()} is missing role ${recoveryAgentRole}`)
+  })
+})

--- a/specs/ve/gauge-pool/withdraw-rewards.spec.js
+++ b/specs/ve/gauge-pool/withdraw-rewards.spec.js
@@ -1,0 +1,111 @@
+const factory = require('../../util/factory')
+const key = require('../../util/key')
+const helper = require('../../util/helper')
+const { mine } = require('@nomicfoundation/hardhat-network-helpers')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Liquidity Gauge Pool: Withdraw Rewards', () => {
+  let contracts, info
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+    await contracts.registry.addOrEditPools([contracts.gaugePool.address])
+
+    const emission = helper.ether(100_00)
+    const distribution = [{ key: info.key, emission }]
+    await contracts.npm.mint(owner.address, emission)
+    await contracts.npm.approve(contracts.registry.address, emission)
+    await contracts.registry.setGauge(1, emission, 28 * DAYS, distribution)
+  })
+
+  it('must allow withdrawing rewards', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks / 2)
+
+    const balanceBeforeWithdraw = await contracts.npm.balanceOf(owner.address)
+
+    const pendingRewards = await contracts.gaugePool.calculateReward(owner.address)
+    await contracts.gaugePool.withdrawRewards()
+
+    const balanceAfterWithdraw = await contracts.npm.balanceOf(owner.address)
+    pendingRewards.should.be.greaterThan(0)
+
+    const fees = BigInt(pendingRewards.toString()) * BigInt(650) / BigInt(10000)
+    balanceAfterWithdraw.should.be.greaterThan(
+      BigInt(balanceBeforeWithdraw.toString()) + BigInt(pendingRewards.toString()) - fees
+    )
+  })
+
+  it('must not allow withdrawing rewards when paused', async () => {
+    const [owner, bob] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    const pauserRole = await contracts.gaugePool.NS_ROLES_PAUSER()
+    await contracts.gaugePool.grantRole(pauserRole, bob.address)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks / 2)
+
+    await contracts.gaugePool.connect(bob).pause()
+    await contracts.gaugePool.withdrawRewards()
+      .should.be.rejectedWith('Pausable: paused')
+
+    await contracts.gaugePool.unpause()
+    await contracts.gaugePool.withdrawRewards()
+  })
+
+  it('must not allow withdrawing rewards after exit', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks)
+
+    await contracts.gaugePool.exit()
+
+    const pendingRewards = await contracts.gaugePool.calculateReward(owner.address)
+    pendingRewards.should.be.equal(0)
+
+    await contracts.gaugePool.withdrawRewards()
+  })
+})

--- a/specs/ve/gauge-pool/withdraw.spec.js
+++ b/specs/ve/gauge-pool/withdraw.spec.js
@@ -1,0 +1,80 @@
+const factory = require('../../util/factory')
+const key = require('../../util/key')
+const helper = require('../../util/helper')
+const { mine } = require('@nomicfoundation/hardhat-network-helpers')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Liquidity Gauge Pool: Withdraw', () => {
+  let contracts, info
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    info = {
+      key: key.toBytes32('foobar'),
+      name: 'Foobar',
+      info: key.toBytes32(''),
+      lockupPeriodInBlocks: 100,
+      epochDuration: 28 * DAYS,
+      veBoostRatio: 1000,
+      platformFee: helper.percentage(6.5),
+      stakingToken: contracts.fakePod.address,
+      veToken: contracts.veNpm.address,
+      rewardToken: contracts.npm.address,
+      registry: contracts.registry.address,
+      treasury: helper.randomAddress()
+    }
+
+    contracts.gaugePool = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, info)
+    await contracts.registry.addOrEditPools([contracts.gaugePool.address])
+
+    const emission = helper.ether(100_00)
+    const distribution = [{ key: info.key, emission }]
+    await contracts.npm.mint(owner.address, emission)
+    await contracts.npm.approve(contracts.registry.address, emission)
+    await contracts.registry.setGauge(1, emission, 28 * DAYS, distribution)
+  })
+
+  it('must allow withdrawing staking tokens', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+
+    const balanceBeforeDeposit = await contracts.fakePod.balanceOf(owner.address)
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks)
+
+    await contracts.gaugePool.withdraw(amountToDeposit)
+    const balanceAfterWithdraw = await contracts.fakePod.balanceOf(owner.address)
+    balanceAfterWithdraw.should.equal(balanceBeforeDeposit)
+  })
+
+  it('must not allow withdrawing before lockup period ends', async () => {
+    const [owner] = await ethers.getSigners()
+    const amountToDeposit = helper.ether(10)
+
+    await contracts.fakePod.mint(owner.address, amountToDeposit)
+    await contracts.fakePod.approve(contracts.gaugePool.address, amountToDeposit)
+
+    await contracts.gaugePool.deposit(amountToDeposit)
+
+    await mine(info.lockupPeriodInBlocks / 2)
+
+    await contracts.gaugePool.withdraw(amountToDeposit)
+      .should.be.rejectedWith('WithdrawalLockedError')
+  })
+})

--- a/specs/ve/gauge-registry/activate-pool.spec.js
+++ b/specs/ve/gauge-registry/activate-pool.spec.js
@@ -6,9 +6,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .should()
 
-const DAYS = 86400
-
-describe('Gauge Controller Registry: Add or Edit Pool', () => {
+describe('Gauge Controller Registry: Activate Pool', () => {
   let contracts
 
   before(async () => {
@@ -39,48 +37,40 @@ describe('Gauge Controller Registry: Add or Edit Pool', () => {
       contracts.pools.push(deployed.address)
       contracts.poolInfo.push(pool)
     }
+
+    // Add pools
+    await contracts.registry.addOrEditPools(contracts.pools)
   })
 
-  it('must correctly add new pools', async () => {
-    await contracts.registry.addOrEditPools(contracts.pools)
-
+  it('must allow activating pools', async () => {
     for (const pool of contracts.poolInfo) {
       const { key, deployed } = pool
 
+      await contracts.registry.deactivatePool(key)
+      await contracts.registry.activatePool(key)
       ; (await contracts.registry._pools(key)).should.equal(deployed.address)
       ; (await contracts.registry._validPools(key)).should.equal(true)
       ; (await contracts.registry._activePools(key)).should.equal(true)
     }
   })
 
-  it('must allow setting the gauges', async () => {
-    const [owner] = await ethers.getSigners()
-    let total = 0
-    const distribution = []
-
+  it('must not allow activating a pool twice', async () => {
     for (const pool of contracts.poolInfo) {
       const { key } = pool
-      const emission = helper.getRandomNumber(100_000, 300_000)
-      total += emission
 
-      distribution.push({ key, emission: helper.ether(emission) })
-    }
-
-    await contracts.npm.mint(owner.address, helper.ether(total))
-    await contracts.npm.approve(contracts.registry.address, helper.ether(total))
-    await contracts.registry.setGauge(1, helper.ether(total), 28 * DAYS, distribution)
-
-    for (const pool of contracts.poolInfo) {
-      ;(await pool.deployed._epoch()).should.equal(1)
+      await contracts.registry.activatePool(key)
+        .should.be.revertedWithCustomError(contracts.registry, 'PoolAlreadyActiveError')
+        .withArgs(key)
     }
   })
 
-  it('must not allow adding same pool twice', async () => {
-    await contracts.registry.addOrEditPools(contracts.pools)
-      .should.be.revertedWithCustomError(contracts.registry, 'PoolAlreadyExistsError')
+  it('must not allow activating a non-existent pool', async () => {
+    await contracts.registry.activatePool(helper.emptyBytes32)
+      .should.be.revertedWithCustomError(contracts.registry, 'PoolNotFoundError')
+      .withArgs(helper.emptyBytes32)
   })
 
-  it('must not allow adding pools when paused', async () => {
+  it('must not allow activating a pool when paused', async () => {
     const [, bob] = await ethers.getSigners()
 
     const pauserRole = await contracts.registry.NS_ROLES_PAUSER()
@@ -88,7 +78,7 @@ describe('Gauge Controller Registry: Add or Edit Pool', () => {
 
     await contracts.registry.connect(bob).pause()
 
-    await contracts.registry.addOrEditPools(contracts.pools)
+    await contracts.registry.activatePool(helper.emptyBytes32)
       .should.be.rejectedWith('Pausable: paused')
 
     await contracts.registry.unpause()

--- a/specs/ve/gauge-registry/ctor.spec.js
+++ b/specs/ve/gauge-registry/ctor.spec.js
@@ -26,4 +26,11 @@ describe('Gauge Controller Registry: Constructor', () => {
     ;(await contracts.registry.hasRole(key.toBytes32('role:pauser'), owner.address)).should.equal(true)
     ;(await contracts.registry._rewardToken()).should.equal(contracts.npm.address)
   })
+
+  it('must not allow to be initialized twice', async () => {
+    const [owner] = await ethers.getSigners()
+
+    await contracts.registry.initialize(0, owner.address, owner.address, [owner.address], contracts.npm.address)
+      .should.be.rejectedWith('Initializable: contract is already initialized')
+  })
 })

--- a/specs/ve/gauge-registry/deactivate-pool.spec.js
+++ b/specs/ve/gauge-registry/deactivate-pool.spec.js
@@ -6,9 +6,7 @@ require('chai')
   .use(require('chai-as-promised'))
   .should()
 
-const DAYS = 86400
-
-describe('Gauge Controller Registry: Add or Edit Pool', () => {
+describe('Gauge Controller Registry: Deactivate Pool', () => {
   let contracts
 
   before(async () => {
@@ -39,48 +37,39 @@ describe('Gauge Controller Registry: Add or Edit Pool', () => {
       contracts.pools.push(deployed.address)
       contracts.poolInfo.push(pool)
     }
+
+    // Add pools
+    await contracts.registry.addOrEditPools(contracts.pools)
   })
 
-  it('must correctly add new pools', async () => {
-    await contracts.registry.addOrEditPools(contracts.pools)
-
+  it('must allow deactivating pools', async () => {
     for (const pool of contracts.poolInfo) {
       const { key, deployed } = pool
 
+      await contracts.registry.deactivatePool(key)
       ; (await contracts.registry._pools(key)).should.equal(deployed.address)
       ; (await contracts.registry._validPools(key)).should.equal(true)
-      ; (await contracts.registry._activePools(key)).should.equal(true)
+      ; (await contracts.registry._activePools(key)).should.equal(false)
     }
   })
 
-  it('must allow setting the gauges', async () => {
-    const [owner] = await ethers.getSigners()
-    let total = 0
-    const distribution = []
-
+  it('must not allow deactivating a pool twice', async () => {
     for (const pool of contracts.poolInfo) {
       const { key } = pool
-      const emission = helper.getRandomNumber(100_000, 300_000)
-      total += emission
 
-      distribution.push({ key, emission: helper.ether(emission) })
-    }
-
-    await contracts.npm.mint(owner.address, helper.ether(total))
-    await contracts.npm.approve(contracts.registry.address, helper.ether(total))
-    await contracts.registry.setGauge(1, helper.ether(total), 28 * DAYS, distribution)
-
-    for (const pool of contracts.poolInfo) {
-      ;(await pool.deployed._epoch()).should.equal(1)
+      await contracts.registry.deactivatePool(key)
+        .should.be.revertedWithCustomError(contracts.registry, 'PoolAlreadyDeactivatedError')
+        .withArgs(key)
     }
   })
 
-  it('must not allow adding same pool twice', async () => {
-    await contracts.registry.addOrEditPools(contracts.pools)
-      .should.be.revertedWithCustomError(contracts.registry, 'PoolAlreadyExistsError')
+  it('must not allow deactivating a non-existent pool', async () => {
+    await contracts.registry.activatePool(helper.emptyBytes32)
+      .should.be.revertedWithCustomError(contracts.registry, 'PoolNotFoundError')
+      .withArgs(helper.emptyBytes32)
   })
 
-  it('must not allow adding pools when paused', async () => {
+  it('must not allow deactivating a pool when paused', async () => {
     const [, bob] = await ethers.getSigners()
 
     const pauserRole = await contracts.registry.NS_ROLES_PAUSER()
@@ -88,7 +77,7 @@ describe('Gauge Controller Registry: Add or Edit Pool', () => {
 
     await contracts.registry.connect(bob).pause()
 
-    await contracts.registry.addOrEditPools(contracts.pools)
+    await contracts.registry.deactivatePool(helper.emptyBytes32)
       .should.be.rejectedWith('Pausable: paused')
 
     await contracts.registry.unpause()

--- a/specs/ve/gauge-registry/pause.spec.js
+++ b/specs/ve/gauge-registry/pause.spec.js
@@ -1,0 +1,96 @@
+const factory = require('../../util/factory')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Gauge Controller Registry: Pause', () => {
+  let contracts, pauserRole
+
+  before(async () => {
+    const [owner, bob] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    pauserRole = await contracts.registry.NS_ROLES_PAUSER()
+    await contracts.registry.grantRole(pauserRole, bob.address)
+  })
+
+  it('must allow to be paused by pauser', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.registry.connect(bob).pause()
+
+    const isPaused = await contracts.registry.paused()
+    isPaused.should.equal(true)
+
+    await contracts.registry.unpause()
+  })
+
+  it('must not allow to be paused by other than pauser', async () => {
+    const [,, charlie] = await ethers.getSigners()
+
+    await contracts.registry.connect(charlie).pause()
+      .should.be.rejectedWith(`AccessControl: account ${charlie.address.toLowerCase()} is missing role ${pauserRole}`)
+  })
+})
+
+describe('Gauge Controller Registry: Unpause', () => {
+  let contracts, pauserRole, adminRole
+
+  before(async () => {
+    const [owner, bob, charlie] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+    contracts.fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    pauserRole = await contracts.registry.NS_ROLES_PAUSER()
+    adminRole = await contracts.registry.DEFAULT_ADMIN_ROLE()
+    await contracts.registry.grantRole(pauserRole, bob.address)
+    await contracts.registry.grantRole(adminRole, charlie.address)
+  })
+
+  it('must allow to be unpaused by owner', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.registry.connect(bob).pause()
+
+    let isPaused = await contracts.registry.paused()
+    isPaused.should.equal(true)
+
+    await contracts.registry.unpause()
+    isPaused = await contracts.registry.paused()
+    isPaused.should.equal(false)
+  })
+
+  it('must allow to be unpaused by admin', async () => {
+    const [, bob, charlie] = await ethers.getSigners()
+
+    await contracts.registry.connect(bob).pause()
+
+    let isPaused = await contracts.registry.paused()
+    isPaused.should.equal(true)
+
+    await contracts.registry.connect(charlie).unpause()
+    isPaused = await contracts.registry.paused()
+    isPaused.should.equal(false)
+  })
+
+  it('must not allow to be unpaused by other than admin', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await contracts.registry.connect(bob).pause()
+
+    await contracts.registry.connect(bob).unpause()
+      .should.be.rejectedWith(`AccessControl: account ${bob.address.toLowerCase()} is missing role ${adminRole}`)
+
+    await contracts.registry.unpause()
+  })
+})

--- a/specs/ve/gauge-registry/recover.spec.js
+++ b/specs/ve/gauge-registry/recover.spec.js
@@ -1,0 +1,108 @@
+const { ethers } = require('hardhat')
+const factory = require('../../util/factory')
+const helper = require('../../util/helper')
+const { forceSendEther } = require('../../util/factory/force-ether')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+describe('Liquidity Gauge Pool: Recover token', () => {
+  let contracts
+
+  before(async () => {
+    const [owner, bob] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.weth = await factory.deployUpgradeable('FakeToken', 'Wrapped ETH', 'WETH')
+
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    // Make bob recovery agent
+    const recoveryAgentRole = await contracts.registry.NS_ROLES_RECOVERY_AGENT()
+    await contracts.registry.grantRole(recoveryAgentRole, bob.address)
+  })
+
+  it('must allow recovering tokens', async () => {
+    const [owner, bob] = await ethers.getSigners()
+
+    await contracts.weth.mint(owner.address, helper.ether(100_000_000))
+    const receiver = helper.randomAddress()
+
+    await contracts.weth.transfer(contracts.registry.address, helper.ether(12340))
+    await contracts.registry.connect(bob).recoverToken(contracts.weth.address, receiver)
+
+    const balance = await contracts.weth.balanceOf(receiver)
+    balance.should.equal(helper.ether(12340))
+  })
+
+  it('must not throw when contract token balance is zero', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.registry.connect(bob).recoverToken(contracts.weth.address, receiver)
+      .should.not.be.rejected
+
+    const balance = await contracts.weth.balanceOf(receiver)
+    balance.should.equal(helper.ether('0'))
+  })
+
+  it('must not allow non recovery agents to recover tokens', async () => {
+    const [, , charlie] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    const recoveryAgentRole = await contracts.registry.NS_ROLES_RECOVERY_AGENT()
+    await contracts.registry.connect(charlie).recoverToken(contracts.weth.address, receiver)
+      .should.be.rejectedWith(`AccessControl: account ${charlie.address.toLowerCase()} is missing role ${recoveryAgentRole}`)
+  })
+})
+
+describe('Liquidity Gauge Pool: Recover ETH', () => {
+  let contracts
+
+  before(async () => {
+    const [owner, bob] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+
+    // Make bob recovery agent
+    const recoveryAgentRole = await contracts.registry.NS_ROLES_RECOVERY_AGENT()
+    await contracts.registry.grantRole(recoveryAgentRole, bob.address)
+  })
+
+  it('must allow recovering ether', async () => {
+    const [owner, bob] = await ethers.getSigners()
+
+    await forceSendEther(contracts.registry.address, owner)
+    const receiver = helper.randomAddress()
+
+    await contracts.registry.connect(bob).recoverEther(receiver)
+
+    const balance = await owner.provider.getBalance(receiver)
+    balance.should.equal(helper.ether(1))
+  })
+
+  it('must not throw when contract ether balance is zero', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.registry.connect(bob).recoverEther(receiver)
+      .should.not.be.rejected
+
+    const balance = await bob.provider.getBalance(receiver)
+    balance.should.equal(helper.ether('0'))
+  })
+
+  it('must not allow non recovery agents to recover ether', async () => {
+    const [, , charlie] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    const recoveryAgentRole = await contracts.registry.NS_ROLES_RECOVERY_AGENT()
+    await contracts.registry.connect(charlie).recoverEther(receiver)
+      .should.be.rejectedWith(`AccessControl: account ${charlie.address.toLowerCase()} is missing role ${recoveryAgentRole}`)
+  })
+})

--- a/specs/ve/gauge-registry/set-gauge.spec.js
+++ b/specs/ve/gauge-registry/set-gauge.spec.js
@@ -1,0 +1,108 @@
+const factory = require('../../util/factory')
+const helper = require('../../util/helper')
+const pools = require('../../../scripts/ve/pools.baseGoerli.json')
+const key = require('../../util/key')
+const { mine } = require('@nomicfoundation/hardhat-network-helpers')
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .should()
+
+const DAYS = 86400
+
+describe('Gauge Controller Registry: Set Gauge', () => {
+  let contracts
+
+  let total = 0
+  const distribution = []
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    contracts = {}
+
+    contracts.npm = await factory.deployUpgradeable('FakeToken', 'Fake Neptune Mutual Token', 'NPM')
+    contracts.veNpm = await factory.deployUpgradeable('VoteEscrowToken', owner.address, contracts.npm.address, owner.address, 'Vote Escrow NPM', 'veNPM')
+
+    contracts.registry = await factory.deployUpgradeable('GaugeControllerRegistry', 0, owner.address, owner.address, [owner.address], contracts.npm.address)
+    contracts.pools = []
+    contracts.poolInfo = []
+
+    for (const pool of pools) {
+      const fakePod = await factory.deployUpgradeable('FakeToken', 'Yield Earning USDC', 'iUSDC-FOO')
+
+      pool.stakingToken = fakePod.address
+      pool.veToken = contracts.veNpm.address
+      pool.rewardToken = contracts.npm.address
+      pool.registry = contracts.registry.address
+      pool.treasury = helper.randomAddress()
+
+      const deployed = await factory.deployUpgradeable('LiquidityGaugePool', owner.address, pool)
+
+      pool.deployed = deployed
+      pool.stakingTokenDeployed = fakePod
+
+      contracts.pools.push(deployed.address)
+      contracts.poolInfo.push(pool)
+    }
+
+    await contracts.registry.addOrEditPools(contracts.pools)
+
+    for (const pool of contracts.poolInfo) {
+      const { key } = pool
+      const emission = helper.getRandomNumber(100_000, 300_000)
+      total += emission
+
+      distribution.push({ key, emission: helper.ether(emission) })
+    }
+  })
+
+  it('must correctly set gauge', async () => {
+    const [owner] = await ethers.getSigners()
+
+    await contracts.npm.mint(owner.address, helper.ether(total))
+    await contracts.npm.approve(contracts.registry.address, helper.ether(total))
+    await contracts.registry.setGauge(1, helper.ether(total), 28 * DAYS, distribution)
+
+    for (const pool of contracts.poolInfo) {
+      ;(await pool.deployed._epoch()).should.equal(1)
+    }
+  })
+
+  it('must not allow setting gauge before previous epoch ends', async () => {
+    const [owner] = await ethers.getSigners()
+    await contracts.npm.mint(owner.address, helper.ether(total))
+    await contracts.npm.approve(contracts.registry.address, helper.ether(total))
+    await contracts.registry.setGauge(2, helper.ether(total), 28 * DAYS, distribution)
+      .should.be.revertedWithCustomError(contracts.poolInfo[0].deployed, 'EpochStillActiveError')
+
+    // Complete epoch
+    await mine(1, { interval: 28 * DAYS })
+  })
+
+  it('must not allow setting gauge for same epoch twice', async () => {
+    const [owner] = await ethers.getSigners()
+    await contracts.npm.mint(owner.address, helper.ether(total))
+    await contracts.npm.approve(contracts.registry.address, helper.ether(total))
+
+    await contracts.registry.setGauge(1, helper.ether(total), 28 * DAYS, distribution)
+      .should.be.revertedWithCustomError(contracts.registry, 'InvalidGaugeEpochError')
+  })
+
+  it('must not allow setting gauge without distribution', async () => {
+    await contracts.registry.setGauge(3, helper.ether(total), 28 * DAYS, [])
+      .should.be.revertedWithCustomError(contracts.registry, 'InvalidArgumentError')
+      .withArgs(key.toBytes32('distribution'))
+  })
+
+  it('must not allow setting gauge without epoch number', async () => {
+    await contracts.registry.setGauge(0, helper.ether(total), 28 * DAYS, distribution)
+      .should.be.revertedWithCustomError(contracts.registry, 'InvalidArgumentError')
+      .withArgs(key.toBytes32('epoch'))
+  })
+
+  it('must not allow setting gauge without epoch duration', async () => {
+    await contracts.registry.setGauge(3, helper.ether(total), 0, distribution)
+      .should.be.revertedWithCustomError(contracts.registry, 'InvalidArgumentError')
+      .withArgs(key.toBytes32('epochDuration'))
+  })
+})

--- a/src/fakes/ForceEther.sol
+++ b/src/fakes/ForceEther.sol
@@ -1,0 +1,15 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.12;
+
+contract ForceEther {
+  event Received(address indexed account, uint256 amount);
+
+  receive() external payable {
+    emit Received(msg.sender, msg.value);
+  }
+
+  function destruct(address payable to) external {
+    selfdestruct(to);
+  }
+}

--- a/src/gauge-registry/GaugeControllerRegistry.sol
+++ b/src/gauge-registry/GaugeControllerRegistry.sol
@@ -48,7 +48,7 @@ contract GaugeControllerRegistry is AccessControlUpgradeable, PausableUpgradeabl
     _rewardToken = rewardToken;
   }
 
-  function addOrEditPools(ILiquidityGaugePool[] calldata pools) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function addOrEditPools(ILiquidityGaugePool[] calldata pools) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
     if (pools.length == 0) {
       revert InvalidArgumentError("pools");
     }
@@ -58,19 +58,19 @@ contract GaugeControllerRegistry is AccessControlUpgradeable, PausableUpgradeabl
     }
   }
 
-  function deactivatePool(bytes32 key) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function deactivatePool(bytes32 key) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
     _deactivatePool(key);
   }
 
-  function activatePool(bytes32 key) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function activatePool(bytes32 key) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
     _activatePool(key);
   }
 
-  function deletePool(bytes32 key) external onlyRole(DEFAULT_ADMIN_ROLE) {
+  function deletePool(bytes32 key) external onlyRole(DEFAULT_ADMIN_ROLE) whenNotPaused {
     _deletePool(key);
   }
 
-  function setGauge(uint256 epoch, uint256 amountToDeposit, uint256 epochDuration, Gauge[] calldata distribution) external onlyRole(NS_GAUGE_AGENT) {
+  function setGauge(uint256 epoch, uint256 amountToDeposit, uint256 epochDuration, Gauge[] calldata distribution) external onlyRole(NS_GAUGE_AGENT) whenNotPaused {
     if (epoch == 0) {
       revert InvalidArgumentError("epoch");
     }


### PR DESCRIPTION
Added tests for following features
- Gauge Controller Registr
  - delete pool
  - activate pool
  - deactivate pool
- Liquidity gauge pools
  - deposit
  - withdraw
  - withdrawRewards
  - exit
- Vote Escrow
  - pause
  - unpause

Also added tests for `recoverToken` and `recoverEther` functions