### PR TITLE
Balance Check and New Error Types

### DIFF
--- a/abis/FakeNeptuneLegends.json
+++ b/abis/FakeNeptuneLegends.json
@@ -53,6 +53,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -65,12 +70,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -134,6 +134,22 @@
       }
     ],
     "name": "SoulboundError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {
@@ -1020,12 +1036,12 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "_tokenId",
+        "name": "tokenId",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "_salePrice",
+        "name": "salePrice",
         "type": "uint256"
       }
     ],

--- a/abis/FakeVoteEscrowLockerV2.json
+++ b/abis/FakeVoteEscrowLockerV2.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -92,6 +92,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/FakeVoteEscrowTokenV2.json
+++ b/abis/FakeVoteEscrowTokenV2.json
@@ -21,6 +21,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -33,12 +38,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -139,6 +139,22 @@
       }
     ],
     "name": "VoteEscrowUnlockOffsetError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/ForceEther.json
+++ b/abis/ForceEther.json
@@ -1,0 +1,38 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Received",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "destruct",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/abis/GaugeControllerRegistry.json
+++ b/abis/GaugeControllerRegistry.json
@@ -21,6 +21,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -33,12 +38,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -147,6 +147,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/GaugeControllerRegistryPool.json
+++ b/abis/GaugeControllerRegistryPool.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -142,6 +142,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/IThrowable.json
+++ b/abis/IThrowable.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -60,6 +60,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/IVoteEscrowToken.json
+++ b/abis/IVoteEscrowToken.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -119,6 +119,22 @@
       }
     ],
     "name": "VoteEscrowUnlockOffsetError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/IWhitelistedTransfer.json
+++ b/abis/IWhitelistedTransfer.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -70,6 +70,22 @@
   {
     "inputs": [],
     "name": "TransferRestrictedError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/IWithPausability.json
+++ b/abis/IWithPausability.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -65,6 +65,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/LiquidityGaugePool.json
+++ b/abis/LiquidityGaugePool.json
@@ -24,22 +24,6 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "required",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "provided",
-        "type": "uint256"
-      }
-    ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
         "name": "endsAt",
         "type": "uint256"
       }
@@ -55,6 +39,22 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -108,6 +108,22 @@
       }
     ],
     "name": "WithdrawalLockedError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/LiquidityGaugePoolController.json
+++ b/abis/LiquidityGaugePoolController.json
@@ -19,22 +19,6 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "required",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "provided",
-        "type": "uint256"
-      }
-    ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
         "name": "endsAt",
         "type": "uint256"
       }
@@ -50,6 +34,22 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -98,6 +98,22 @@
       }
     ],
     "name": "WithdrawalLockedError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/LiquidityGaugePoolReward.json
+++ b/abis/LiquidityGaugePoolReward.json
@@ -19,22 +19,6 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "required",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "provided",
-        "type": "uint256"
-      }
-    ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
         "name": "endsAt",
         "type": "uint256"
       }
@@ -50,6 +34,22 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -98,6 +98,22 @@
       }
     ],
     "name": "WithdrawalLockedError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/MerkleProofMinter.json
+++ b/abis/MerkleProofMinter.json
@@ -21,6 +21,16 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "DuplicateRootError",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -33,17 +43,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "DuplicateRootError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -193,6 +193,22 @@
       }
     ],
     "name": "TokenIdOutOfBoundsError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/NeptuneLegends.json
+++ b/abis/NeptuneLegends.json
@@ -53,6 +53,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -65,12 +70,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -134,6 +134,22 @@
       }
     ],
     "name": "SoulboundError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {
@@ -1064,12 +1080,12 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "_tokenId",
+        "name": "tokenId",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "_salePrice",
+        "name": "salePrice",
         "type": "uint256"
       }
     ],

--- a/abis/PolicyProofMinter.json
+++ b/abis/PolicyProofMinter.json
@@ -24,22 +24,6 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "required",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "provided",
-        "type": "uint256"
-      }
-    ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
         "name": "expiredOn",
         "type": "uint256"
       }
@@ -50,6 +34,22 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -130,6 +130,22 @@
       }
     ],
     "name": "TokenIdOutOfBoundsError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/ProofOfPolicy.json
+++ b/abis/ProofOfPolicy.json
@@ -19,22 +19,6 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "required",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "provided",
-        "type": "uint256"
-      }
-    ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
         "name": "expiredOn",
         "type": "uint256"
       }
@@ -45,6 +29,22 @@
   {
     "inputs": [],
     "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "required",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "provided",
+        "type": "uint256"
+      }
+    ],
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -87,6 +87,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/ProtocolMembership.json
+++ b/abis/ProtocolMembership.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -60,6 +60,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/Token.json
+++ b/abis/Token.json
@@ -21,6 +21,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -33,12 +38,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -65,6 +65,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/TokenRecovery.json
+++ b/abis/TokenRecovery.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -60,6 +60,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/VoteEscrowLocker.json
+++ b/abis/VoteEscrowLocker.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -92,6 +92,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/VoteEscrowToken.json
+++ b/abis/VoteEscrowToken.json
@@ -21,6 +21,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -33,12 +38,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -139,6 +139,22 @@
       }
     ],
     "name": "VoteEscrowUnlockOffsetError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/WhitelistedTransfer.json
+++ b/abis/WhitelistedTransfer.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -70,6 +70,22 @@
   {
     "inputs": [],
     "name": "TransferRestrictedError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/abis/WithPausability.json
+++ b/abis/WithPausability.json
@@ -16,6 +16,11 @@
     "type": "error"
   },
   {
+    "inputs": [],
+    "name": "ExternalContractInvocationRevertError",
+    "type": "error"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -28,12 +33,7 @@
         "type": "uint256"
       }
     ],
-    "name": "BalanceInsufficientError",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "ExternalContractInvocationRevertError",
+    "name": "InsufficientDepositError",
     "type": "error"
   },
   {
@@ -65,6 +65,22 @@
   {
     "inputs": [],
     "name": "RelatedArrayItemCountMismatchError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "requested",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawalTooHighError",
     "type": "error"
   },
   {

--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -73,6 +73,10 @@ contract LiquidityGaugePool is IAccessControlUtil, ReentrancyGuardUpgradeable, A
       revert ZeroAmountError("amount");
     }
 
+    if (amount > _lockedByMe[_msgSender()]) {
+      revert WithdrawalTooHighError(_lockedByMe[_msgSender()], amount);
+    }
+
     if (block.number < _lastDepositHeights[_msgSender()] + _poolInfo.lockupPeriodInBlocks) {
       revert WithdrawalLockedError(_lastDepositHeights[_msgSender()] + _poolInfo.lockupPeriodInBlocks);
     }
@@ -151,7 +155,7 @@ contract LiquidityGaugePool is IAccessControlUtil, ReentrancyGuardUpgradeable, A
     _epoch = epoch;
 
     if (_poolInfo.epochDuration * _rewardPerSecond > IERC20Upgradeable(_poolInfo.rewardToken).balanceOf(address(this))) {
-      revert BalanceInsufficientError(_poolInfo.epochDuration * _rewardPerSecond, IERC20Upgradeable(_poolInfo.rewardToken).balanceOf(address(this)));
+      revert InsufficientDepositError(_poolInfo.epochDuration * _rewardPerSecond, IERC20Upgradeable(_poolInfo.rewardToken).balanceOf(address(this)));
     }
 
     _lastRewardTimestamp = block.timestamp;

--- a/src/gauge-registry/GaugeControllerRegistry.sol
+++ b/src/gauge-registry/GaugeControllerRegistry.sol
@@ -119,7 +119,7 @@ contract GaugeControllerRegistry is IAccessControlUtil, AccessControlUpgradeable
     }
 
     if (amountToDeposit < total) {
-      revert BalanceInsufficientError(total, amountToDeposit);
+      revert InsufficientDepositError(total, amountToDeposit);
     }
 
     _epochDurations[epoch] = epochDuration;

--- a/src/nft-minter/merkle/MerkleProofMinter.sol
+++ b/src/nft-minter/merkle/MerkleProofMinter.sol
@@ -102,8 +102,6 @@ contract MerkleProofMinter is IAccessControlUtil, AccessControlUpgradeable, Paus
       revert PersonaMismatchError(persona, _personas[_msgSender()][level]);
     }
 
-    // @todo: not during withdrawal period
-
     Boundary storage boundary = _boundaries[level][family];
 
     if (tokenId < boundary.min || tokenId > boundary.max) {

--- a/src/util/interfaces/IThrowable.sol
+++ b/src/util/interfaces/IThrowable.sol
@@ -12,5 +12,6 @@ interface IThrowable {
   error InvalidArgumentError(bytes32 argument);
   error ZeroAmountError(bytes32 argument);
   error ZeroAddressError(bytes32 argument);
-  error BalanceInsufficientError(uint256 required, uint256 provided);
+  error InsufficientDepositError(uint256 required, uint256 provided);
+  error WithdrawalTooHighError(uint256 balance, uint256 requested);
 }


### PR DESCRIPTION
- Introduced a new error type: `WithdrawalTooHighError`
- Refactored the `_withdraw` function in the `LiquidityGaugePool` to throw a `WithdrawalTooHighError` when the requested withdrawal amount exceeds the account balance
- Renamed `BalanceInsufficientError` to `InsufficientDepositError` in `GaugeControllerRegistry`, `LiquidityGaugePool`, and `IThrowable` for the sake of clarity
- Updated ABIs