### PR TITLE
Transfer tokens before updating the internal state

### DIFF
--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -73,13 +73,13 @@ contract LiquidityGaugePool is IAccessControlUtil, AccessControlUpgradeable, Pau
       revert EpochUnavailableError();
     }
 
+    IERC20Upgradeable(_poolInfo.stakingToken).safeTransferFrom(_msgSender(), address(this), amount);
+
     _updateReward(_msgSender());
 
     _lockedByEveryone += amount;
     _lockedByMe[_msgSender()] += amount;
     _lastDepositHeights[_msgSender()] = block.number;
-
-    IERC20Upgradeable(_poolInfo.stakingToken).safeTransferFrom(_msgSender(), address(this), amount);
 
     emit LiquidityGaugeDeposited(_poolInfo.key, _msgSender(), _poolInfo.stakingToken, amount);
   }


### PR DESCRIPTION
Updated `deposit()` to transfer the tokens before changing any internal state. This ensures that user has necessary tokens and allowances.