### PR TITLE
Added token validation to `recoverToken` function

### DIFF
--- a/specs/escrow/pausable/pause.spec.js
+++ b/specs/escrow/pausable/pause.spec.js
@@ -1,5 +1,5 @@
 const factory = require('../../util/factory')
-const helper = require('../../util/key')
+const key = require('../../util/key')
 
 require('chai')
   .use(require('chai-as-promised'))
@@ -32,7 +32,7 @@ describe('Vote Escrow Token: Pause/Unpause', () => {
   it('must not allow non pausers to pause', async () => {
     await contracts.veToken.pause()
       .should.be.revertedWithCustomError(contracts.veToken, 'AccessDeniedError')
-      .withArgs(helper.toBytes32('Pauser'))
+      .withArgs(key.toBytes32('Pauser'))
   })
 
   it('must not allow non owners to unpause', async () => {

--- a/specs/nft/pause.spec.js
+++ b/specs/nft/pause.spec.js
@@ -1,4 +1,4 @@
-const helper = require('../util/key')
+const key = require('../util/key')
 const { deployUpgradeable } = require('../util/factory')
 
 require('chai')
@@ -25,7 +25,7 @@ describe('NFT: Pause/Unpause', () => {
   it('must not allow non pausers to pause', async () => {
     await nft.pause()
       .should.be.revertedWithCustomError(nft, 'AccessDeniedError')
-      .withArgs(helper.toBytes32('role:pauser'))
+      .withArgs(key.toBytes32('role:pauser'))
   })
 
   it('must not allow non owners to unpause', async () => {

--- a/specs/ve/gauge-pool/recover.spec.js
+++ b/specs/ve/gauge-pool/recover.spec.js
@@ -147,6 +147,24 @@ describe('Liquidity Gauge Pool: Recover Ether', () => {
     balance.should.equal(helper.ether('0'))
   })
 
+  it('must not allow to recover staking token', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.gaugePool.connect(bob).recoverToken(info.stakingToken, receiver)
+      .should.be.revertedWithCustomError(contracts.gaugePool, 'InvalidArgumentError')
+      .withArgs(key.toBytes32('malicious'))
+  })
+
+  it('must not allow to recover reward token', async () => {
+    const [, bob] = await ethers.getSigners()
+    const receiver = helper.randomAddress()
+
+    await contracts.gaugePool.connect(bob).recoverToken(info.rewardToken, receiver)
+      .should.be.revertedWithCustomError(contracts.gaugePool, 'InvalidArgumentError')
+      .withArgs(key.toBytes32('malicious'))
+  })
+
   it('must not allow non recovery agents to recover ether', async () => {
     const [, , charlie] = await ethers.getSigners()
     const receiver = helper.randomAddress()

--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -184,6 +184,10 @@ contract LiquidityGaugePool is IAccessControlUtil, AccessControlUpgradeable, Pau
   }
 
   function recoverToken(IERC20Upgradeable malicious, address sendTo) external onlyRole(_NS_ROLES_RECOVERY_AGENT) {
+    if (address(malicious) == _poolInfo.stakingToken || address(malicious) == _poolInfo.rewardToken) {
+      revert InvalidArgumentError("malicious");
+    }
+
     _recoverToken(malicious, sendTo);
   }
 


### PR DESCRIPTION
- Restricted `recoverToken()` from transferring staking or reward tokens
- Updated tests