### PR TITLE
Restrict `setPool` to be accessible only outside epoch

### DIFF
--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -83,6 +83,10 @@ contract LiquidityGaugePool is IAccessControlUtil, AccessControlUpgradeable, Pau
   }
 
   function setPool(PoolInfo calldata args) external override onlyRole(DEFAULT_ADMIN_ROLE) {
+    if (block.timestamp <= _epochEndTimestamp) {
+      revert EpochUnavailableError();
+    }
+    
     _setPool(args);
   }
 


### PR DESCRIPTION
Updated so that when admin tries to call `setPool()`, then the transaction will revert with `EpochUnavailableError` error