### PR TITLE
Added feature for emergency withdrawal

### DIFF
--- a/src/gauge-pool/LiquidityGaugePoolReward.sol
+++ b/src/gauge-pool/LiquidityGaugePoolReward.sol
@@ -32,7 +32,7 @@ abstract contract LiquidityGaugePoolReward is LiquidityGaugePoolController {
     return pending + ((myWeight * (_getRewardPerTokenUnit() - _lastRewardPerTokenUnit[account])) / 1e18);
   }
 
-  function _updateReward(address account) internal {
+  function _updateReward(address account, bool emergency) internal {
     _rewardPerTokenUnit = _getRewardPerTokenUnit();
     _lastRewardTimestamp = _getEpochEndTimestamp();
 
@@ -41,7 +41,9 @@ abstract contract LiquidityGaugePoolReward is LiquidityGaugePoolController {
       _lastRewardPerTokenUnit[account] = _rewardPerTokenUnit;
     }
 
-    _updateVotingPowers();
+    if(!emergency){
+      _updateVotingPowers();
+    }
   }
 
   function _updateVotingPowers() private {

--- a/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
+++ b/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
@@ -29,6 +29,7 @@ interface ILiquidityGaugePool {
   function withdraw(uint256 amount) external;
   function withdrawRewards() external;
   function exit() external;
+  function emergencyWithdraw() external;
 
   function setPool(PoolInfo calldata args) external;
   function setEpoch(uint256 epoch, uint256 epochDuration, uint256 rewards) external;


### PR DESCRIPTION
Added feature which allows users to withdraw their locked tokens during emergencies.
If there is an error in `veToken` contract's `getVotingPower()` this feature can be utilized.