### PR TITLE
Remove redundant validation

### DIFF
--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -170,10 +170,6 @@ contract LiquidityGaugePool is IAccessControlUtil, AccessControlUpgradeable, Pau
     if (rewards > 0) {
       uint256 platformFee = (rewards * _poolInfo.platformFee) / _denominator();
 
-      if (rewards <= platformFee) {
-        revert PlatformFeeTooHighError(_poolInfo.platformFee);
-      }
-
       _pendingRewardToDistribute[_msgSender()] = 0;
       IERC20Upgradeable(_poolInfo.rewardToken).safeTransfer(_msgSender(), rewards - platformFee);
 

--- a/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
+++ b/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
@@ -36,5 +36,4 @@ interface ILiquidityGaugePool {
 
   error WithdrawalLockedError(uint256 waitUntilHeight);
   error EpochUnavailableError();
-  error PlatformFeeTooHighError(uint256 platformFee);
 }


### PR DESCRIPTION
Remove redundant check for `PlatformFeeTooHighError`. The following conditions make sure that the fees are always less than rewards
- `platformFee` cannot be greater than 2000
- `denominator()` returns 10000