### PR TITLE
Refactored PoolInfo and Initialization Arguments

### DIFF
--- a/src/gauge-pool/LiquidityGaugePoolController.sol
+++ b/src/gauge-pool/LiquidityGaugePoolController.sol
@@ -8,7 +8,7 @@ import "./LiquidityGaugePoolState.sol";
 
 abstract contract LiquidityGaugePoolController is IThrowable, AccessControlUpgradeable, LiquidityGaugePoolState {
   modifier onlyRegistry() {
-    if (_msgSender() != _poolInfo.registry) {
+    if (_msgSender() != _registry) {
       revert AccessDeniedError("Registry");
     }
 
@@ -16,35 +16,37 @@ abstract contract LiquidityGaugePoolController is IThrowable, AccessControlUpgra
   }
 
   function _setPool(PoolInfo calldata args) internal {
-    if (args.epochDuration > 0) {
-      _poolInfo.epochDuration = args.epochDuration;
+    if (bytes(args.name).length == 0) {
+      revert InvalidArgumentError("args.name");
     }
 
-    if (args.veBoostRatio > 0) {
-      _poolInfo.veBoostRatio = args.veBoostRatio;
+    if (bytes(args.info).length == 0) {
+      revert InvalidArgumentError("args.info");
     }
 
-    if (args.treasury != address(0)) {
-      _poolInfo.treasury = args.treasury;
+    if (args.epochDuration == 0) {
+      revert InvalidArgumentError("args.epochDuration");
     }
 
-    if (bytes(args.name).length > 0) {
-      _poolInfo.name = args.name;
+    if (args.veBoostRatio == 0) {
+      revert InvalidArgumentError("args.veBoostRatio");
     }
 
-    if (bytes(args.info).length > 0) {
-      _poolInfo.info = args.info;
+    if (args.treasury == address(0)) {
+      revert InvalidArgumentError("args.treasury");
     }
 
-    if (args.platformFee > 0) {
-      _poolInfo.platformFee = args.platformFee;
+    if (args.platformFee > _MAX_PLATFORM_FEE) {
+      revert InvalidArgumentError("args.platformFee");
     }
+    
+    _poolInfo = args;
 
-    emit LiquidityGaugePoolSet(_poolInfo.key, _msgSender(), address(this), args);
+    emit LiquidityGaugePoolSet(_key, _msgSender(), address(this), args);
   }
 
   function _setEpochDuration(uint256 epochDuration) internal {
-    emit EpochDurationUpdated(_poolInfo.key, _poolInfo.epochDuration, epochDuration);
+    emit EpochDurationUpdated(_key, _poolInfo.epochDuration, epochDuration);
 
     _poolInfo.epochDuration = epochDuration;
   }

--- a/src/gauge-pool/LiquidityGaugePoolReward.sol
+++ b/src/gauge-pool/LiquidityGaugePoolReward.sol
@@ -50,11 +50,11 @@ abstract contract LiquidityGaugePoolReward is LiquidityGaugePoolController {
     uint256 previous = _myVotingPower[_msgSender()];
     uint256 previousTotal = _totalVotingPower;
 
-    uint256 current = IVoteEscrowToken(_poolInfo.veToken).getVotingPower(_msgSender());
+    uint256 current = IVoteEscrowToken(_veToken).getVotingPower(_msgSender());
 
     _totalVotingPower = _totalVotingPower + current - previous;
     _myVotingPower[_msgSender()] = current;
 
-    emit VotingPowersUpdated(_poolInfo.key, _msgSender(), previous, current, previousTotal, _totalVotingPower);
+    emit VotingPowersUpdated(_key, _msgSender(), previous, current, previousTotal, _totalVotingPower);
   }
 }

--- a/src/gauge-pool/LiquidityGaugePoolState.sol
+++ b/src/gauge-pool/LiquidityGaugePoolState.sol
@@ -21,6 +21,12 @@ abstract contract LiquidityGaugePoolState is ILiquidityGaugePool {
   uint256 public _rewardPerTokenUnit;
   uint256 public _totalVotingPower;
 
+  bytes32 public _key;
+  address public _registry;
+  address public _rewardToken;
+  address public _stakingToken;
+  address public _veToken;
+
   PoolInfo public _poolInfo;
 
   mapping(address => uint256) public _lastDepositHeights;

--- a/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
+++ b/src/gauge-pool/interfaces/ILiquidityGaugePool.sol
@@ -4,22 +4,27 @@ pragma solidity ^0.8.12;
 
 interface ILiquidityGaugePool {
   struct PoolInfo {
-    bytes32 key;
     string name;
     string info;
     uint256 epochDuration;
     uint256 veBoostRatio;
     uint256 platformFee;
+    address treasury;
+  }
+
+  struct InitializationArgs {
+    bytes32 key;
     address stakingToken;
     address veToken;
     address rewardToken;
     address registry;
-    address treasury;
+    PoolInfo poolInfo;
   }
 
   event EpochRewardSet(bytes32 indexed key, address indexed triggeredBy, uint256 rewards);
   event EpochDurationUpdated(bytes32 indexed key, uint256 previous, uint256 current);
   event VotingPowersUpdated(bytes32 indexed key, address indexed triggeredBy, uint256 previous, uint256 current, uint256 previousTotal, uint256 currentTotal);
+  event LiquidityGaugePoolInitialized(bytes32 indexed key, address indexed initializedBy, InitializationArgs args);
   event LiquidityGaugePoolSet(bytes32 indexed key, address indexed triggeredBy, address liquidityGaugePool, PoolInfo args);
   event LiquidityGaugeDeposited(bytes32 indexed key, address indexed account, address indexed stakingToken, uint256 amount);
   event LiquidityGaugeWithdrawn(bytes32 indexed key, address indexed account, address indexed stakingToken, uint256 amount);


### PR DESCRIPTION
- Refactored PoolInfo to only contain fields that can be modified after initialization
- Updated `args` of `initialize()` to include poolInfo and other fields
- Created individual storage variables for values which cannot be modified after initialization