### PR TITLE
Fixed validation of reward token balance

### DIFF
--- a/src/gauge-pool/LiquidityGaugePool.sol
+++ b/src/gauge-pool/LiquidityGaugePool.sol
@@ -197,15 +197,19 @@ contract LiquidityGaugePool is IAccessControlUtil, AccessControlUpgradeable, Pau
     }
 
     _epoch = epoch;
+    _rewardAllocation = _poolInfo.epochDuration * _rewardPerSecond;
 
-    if (_poolInfo.epochDuration * _rewardPerSecond > IERC20Upgradeable(_rewardToken).balanceOf(address(this))) {
-      revert InsufficientDepositError(_poolInfo.epochDuration * _rewardPerSecond, IERC20Upgradeable(_rewardToken).balanceOf(address(this)));
+    uint256 requiredBalance = _rewardToken == _stakingToken ? _rewardAllocation + _lockedByEveryone : _rewardAllocation;
+    uint256 rewardTokenBalance = IERC20Upgradeable(_rewardToken).balanceOf(address(this));
+
+    if (requiredBalance > rewardTokenBalance) {
+      revert InsufficientDepositError(requiredBalance, rewardTokenBalance);
     }
 
     _lastRewardTimestamp = block.timestamp;
     _epochEndTimestamp = block.timestamp + _poolInfo.epochDuration;
 
-    emit EpochRewardSet(_key, _msgSender(), rewards);
+    emit EpochRewardSet(_key, _msgSender(), _rewardAllocation);
   }
 
   // ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/gauge-pool/LiquidityGaugePoolState.sol
+++ b/src/gauge-pool/LiquidityGaugePoolState.sol
@@ -17,6 +17,7 @@ abstract contract LiquidityGaugePoolState is ILiquidityGaugePool {
   uint256 public _epochEndTimestamp;
   uint256 public _lastRewardTimestamp;
   uint256 public _lockedByEveryone;
+  uint256 public _rewardAllocation;
   uint256 public _rewardPerSecond;
   uint256 public _rewardPerTokenUnit;
   uint256 public _totalVotingPower;


### PR DESCRIPTION
- Fixed validation of reward token balance, modified condition to consider user deposits when `stakingToken` is same as `rewardToken`
- Added a new variable `_rewardAllocation` to store rewards allocated for current epoch